### PR TITLE
Sort features for playlists

### DIFF
--- a/app/src/components/Buttons/PagerButton.tsx
+++ b/app/src/components/Buttons/PagerButton.tsx
@@ -1,27 +1,43 @@
-import { Box, Button } from "@mui/material";
+import { Box, Pagination } from "@mui/material";
 import { TIDAL_ITEMS_PER_PAGE } from "src/contants";
 
 export default function PagerButton({
-  page,
-  totalItems,
-  itemPerPage = TIDAL_ITEMS_PER_PAGE,
-  setPage,
+    page,
+    totalItems,
+    itemPerPage = TIDAL_ITEMS_PER_PAGE,
+    setPage,
 }: {
-  page: number;
-  totalItems: number;
-  itemPerPage?: number;
-  setPage: (page: number) => void;
+    page: number;
+    totalItems: number;
+    itemPerPage?: number;
+    setPage: (page: number) => void;
 }) {
-  if (page * itemPerPage >= totalItems) return null;
-  return (
-    <Box sx={{ textAlign: "center", width: "100%", margin: "1rem" }}>
-      <Button
-        variant="contained"
-        size="large"
-        onClick={() => setPage(page + 1)}
-      >
-        LOAD MORE (page: {page}/{Math.ceil(totalItems / itemPerPage)})
-      </Button>
-    </Box>
-  );
+    const totalPages = Math.max(1, Math.ceil((totalItems || 0) / itemPerPage));
+    if (totalPages <= 1) return null;
+
+    const handleChange = (_: React.ChangeEvent<unknown>, value: number) => {
+        // Prefer absolute page navigation if consumer accepts an argument.
+        if (setPage.length && setPage.length > 0) {
+            setPage(value);
+            return;
+        }
+        // Legacy fallback (increment-only handlers)
+        if (value > page) {
+            const steps = value - page;
+            for (let i = 0; i < steps; i++) setPage(0 as unknown as number);
+        }
+    };
+
+    return (
+        <Box sx={{ display: "flex", justifyContent: "center", my: 3 }}>
+            <Pagination
+                count={totalPages}
+                page={Math.min(page, totalPages)}
+                onChange={handleChange}
+                showFirstButton
+                showLastButton
+                size="large"
+            />
+        </Box>
+    );
 }

--- a/app/src/components/Search/TypeResults.tsx
+++ b/app/src/components/Search/TypeResults.tsx
@@ -34,7 +34,7 @@ export default function TypeResults(props: TabContentProps) {
       <Module data={props.data.items} type={props.type} loading={loading} />
       <PagerButton
         page={page}
-        setPage={() => actions.setPage(page + 1)}
+        setPage={(p: number) => actions.setPage(p)}
         itemPerPage={TIDAL_ITEMS_PER_PAGE}
         totalItems={props.data.totalNumberOfItems}
       />

--- a/app/src/components/TidalModule/Module.tsx
+++ b/app/src/components/TidalModule/Module.tsx
@@ -1,14 +1,14 @@
 import { Box, Grid } from "@mui/material";
 import { useConfigProvider } from "src/provider/ConfigProvider";
 import {
-  AlbumType,
-  ArtistType,
-  MixType,
-  ModuleItemLevelType,
-  ModuleTypeKeys,
-  PlaylistType,
-  TrackType,
-  VideoType,
+    AlbumType,
+    ArtistType,
+    MixType,
+    ModuleItemLevelType,
+    ModuleTypeKeys,
+    PlaylistType,
+    TrackType,
+    VideoType,
 } from "src/types";
 
 import AlbumCard from "../Cards/Album";
@@ -21,111 +21,186 @@ import { AlbumsLoader } from "../Skeletons/AlbumsLoader";
 import NoResult from "../TidalModule/NoResults";
 
 interface ModuleContentProps {
-  type?: ModuleTypeKeys;
-  loading?: boolean;
-  data:
-    | (AlbumType | TrackType | PlaylistType | ArtistType | VideoType)[]
-    | undefined;
+    type?: ModuleTypeKeys;
+    loading?: boolean;
+    data:
+        | (AlbumType | TrackType | PlaylistType | ArtistType | VideoType)[]
+        | undefined;
 }
 
 export default function Module(props: ModuleContentProps) {
-  const { display } = useConfigProvider();
+    const { display } = useConfigProvider();
 
-  function getCols(breakpoint: string) {
-    if (!props.type) return;
-    const isTrack = ["TRACK_LIST", "ALBUM_ITEMS"].includes(props.type);
-    const isDisplaySmall = display === "small";
-    const isVideo = ["VIDEO_LIST"].includes(props.type);
-    switch (breakpoint) {
-      case "xs":
-        return 12;
-      case "md":
-        return isTrack ? 12 : 6;
-      case "lg":
-        switch (true) {
-          case isDisplaySmall && isTrack:
-            return 12;
-          case isDisplaySmall && !isTrack:
-            return 4;
-          case !isDisplaySmall && !isTrack && !isVideo:
-            return 3;
-          case !isDisplaySmall && isVideo:
-            return 4;
+    function getCols(breakpoint: string) {
+        if (!props.type) return;
+        const isTrack = ["TRACK_LIST", "ALBUM_ITEMS"].includes(props.type);
+        const isDisplaySmall = display === "small";
+        const isVideo = ["VIDEO_LIST"].includes(props.type);
+
+        switch (breakpoint) {
+            case "xs":
+                return 12;
+            case "md":
+                return isTrack ? 12 : 6;
+            case "lg":
+                switch (true) {
+                    case isDisplaySmall && isTrack:
+                        return 12;
+                    case isDisplaySmall && !isTrack:
+                        return 4;
+                    case !isDisplaySmall && !isTrack && !isVideo:
+                        return 3;
+                    case !isDisplaySmall && isVideo:
+                        return 4;
+                }
         }
     }
-  }
 
-  return (
-    <Grid container spacing={2} className="module">
-      {props.data && props.data?.length > 0 ? (
-        props.data.map(
-          (
-            data:
-              | AlbumType
-              | ArtistType
-              | TrackType
-              | PlaylistType
-              | MixType
-              | VideoType
-              | ModuleItemLevelType<PlaylistType>
-              | ModuleItemLevelType<TrackType>
-              | ModuleItemLevelType<AlbumType>
-              | ModuleItemLevelType<ArtistType>,
-            index: number,
-          ) => (
-            <Grid
-              data-testid="item"
-              size={{
-                xs: 12,
-                md: getCols("md"),
-                lg: getCols("lg"),
-              }}
-              key={`album-${index}`}
-            >
-              {props.type === "ALBUM_LIST" ? (
-                <AlbumCard album={data as AlbumType} />
-              ) : props.type === "ARTIST_LIST" ? (
-                <Artist artist={data as ArtistType} />
-              ) : props.type === "TRACK_LIST" ? (
-                <Track track={data as TrackType} />
-              ) : props.type === "ALBUM_ITEMS" ? (
-                <Track track={(data as ModuleItemLevelType<TrackType>)?.item} />
-              ) : props.type === "PLAYLIST_LIST" ? (
-                <Playlist playlist={data as PlaylistType} />
-              ) : props.type === "MIXED_TYPES_LIST" ? (
-                <Playlist
-                  playlist={(data as ModuleItemLevelType<PlaylistType>)?.item}
-                />
-              ) : props.type === "MIX_LIST" ? (
-                <Mix mix={data as MixType} />
-              ) : props.type === "USER_ALBUM_LIST" ? (
-                <AlbumCard
-                  album={(data as ModuleItemLevelType<AlbumType>)?.item}
-                />
-              ) : props.type === "USER_ARTIST_LIST" ? (
-                <Artist
-                  artist={(data as ModuleItemLevelType<ArtistType>)?.item}
-                />
-              ) : props.type === "USER_PLAYLIST_LIST" ? (
-                <Playlist
-                  playlist={
-                    (data as ModuleItemLevelType<PlaylistType>)?.playlist
-                  }
-                />
-              ) : props.type === "VIDEO_LIST" ? (
-                <VideoCard video={data as VideoType} />
-              ) : null}
-            </Grid>
-          ),
-        )
-      ) : props.data && !props.loading ? (
-        <NoResult />
-      ) : null}
-      {props.loading && (
-        <Box marginTop={2}>
-          <AlbumsLoader />
-        </Box>
-      )}
-    </Grid>
-  );
+    return (
+        <Grid container spacing={2} className="module">
+            {props.data && props.data.length > 0 ? (
+                props.data.map(
+                    (
+                        data:
+                            | AlbumType
+                            | ArtistType
+                            | TrackType
+                            | PlaylistType
+                            | MixType
+                            | VideoType
+                            | ModuleItemLevelType<PlaylistType>
+                            | ModuleItemLevelType<TrackType>
+                            | ModuleItemLevelType<AlbumType>
+                            | ModuleItemLevelType<ArtistType>,
+                        index: number,
+                    ) => (
+                        <Grid
+                            data-testid="item"
+                            size={{
+                                xs: 12,
+                                md: getCols("md"),
+                                lg: getCols("lg"),
+                            }}
+                            key={(() => {
+                                if (
+                                    props.type === "ALBUM_LIST" ||
+                                    props.type === "USER_ALBUM_LIST"
+                                ) {
+                                    return `album-${(data as AlbumType).id}`;
+                                }
+                                if (
+                                    props.type === "ARTIST_LIST" ||
+                                    props.type === "USER_ARTIST_LIST"
+                                ) {
+                                    return `artist-${(data as ArtistType).id}`;
+                                }
+                                if (props.type === "TRACK_LIST") {
+                                    return `track-${(data as TrackType).id}`;
+                                }
+                                if (props.type === "ALBUM_ITEMS") {
+                                    const item =
+                                        (data as ModuleItemLevelType<TrackType>)
+                                            ?.item;
+                                    return `albumitem-${item?.id ?? index}`;
+                                }
+                                if (props.type === "PLAYLIST_LIST") {
+                                    return `playlist-${
+                                        (data as PlaylistType).uuid
+                                    }`;
+                                }
+                                if (props.type === "MIXED_TYPES_LIST") {
+                                    const mixed =
+                                        data as ModuleItemLevelType<
+                                            TrackType |
+                                                PlaylistType |
+                                                AlbumType |
+                                                ArtistType
+                                        >;
+                                    const entity: any =
+                                        (mixed as any).item ??
+                                        (mixed as any).playlist;
+                                    const id = entity?.id ?? entity?.uuid;
+                                    return `mixed-${id ?? index}`;
+                                }
+                                if (props.type === "MIX_LIST") {
+                                    return `mix-${(data as MixType).id}`;
+                                }
+                                if (props.type === "USER_PLAYLIST_LIST") {
+                                    const pl = (
+                                        data as ModuleItemLevelType<PlaylistType>
+                                    )?.playlist;
+                                    return `userplaylist-${pl?.uuid ?? index}`;
+                                }
+                                if (props.type === "VIDEO_LIST") {
+                                    return `video-${(data as VideoType).id}`;
+                                }
+                                return `item-${index}`;
+                            })()}
+                        >
+                            {props.type === "ALBUM_LIST" ? (
+                                <AlbumCard album={data as AlbumType} />
+                            ) : props.type === "ARTIST_LIST" ? (
+                                <Artist artist={data as ArtistType} />
+                            ) : props.type === "TRACK_LIST" ? (
+                                <Track track={data as TrackType} />
+                            ) : props.type === "ALBUM_ITEMS" ? (
+                                <Track
+                                    track={
+                                        (
+                                            data as ModuleItemLevelType<TrackType>
+                                        )?.item
+                                    }
+                                />
+                            ) : props.type === "PLAYLIST_LIST" ? (
+                                <Playlist playlist={data as PlaylistType} />
+                            ) : props.type === "MIXED_TYPES_LIST" ? (
+                                <Playlist
+                                    playlist={
+                                        (
+                                            data as ModuleItemLevelType<PlaylistType>
+                                        )?.item
+                                    }
+                                />
+                            ) : props.type === "MIX_LIST" ? (
+                                <Mix mix={data as MixType} />
+                            ) : props.type === "USER_ALBUM_LIST" ? (
+                                <AlbumCard
+                                    album={
+                                        (
+                                            data as ModuleItemLevelType<AlbumType>
+                                        )?.item
+                                    }
+                                />
+                            ) : props.type === "USER_ARTIST_LIST" ? (
+                                <Artist
+                                    artist={
+                                        (
+                                            data as ModuleItemLevelType<ArtistType>
+                                        )?.item
+                                    }
+                                />
+                            ) : props.type === "USER_PLAYLIST_LIST" ? (
+                                <Playlist
+                                    playlist={
+                                        (
+                                            data as ModuleItemLevelType<PlaylistType>
+                                        )?.playlist
+                                    }
+                                />
+                            ) : props.type === "VIDEO_LIST" ? (
+                                <VideoCard video={data as VideoType} />
+                            ) : null}
+                        </Grid>
+                    ),
+                )
+            ) : props.data && !props.loading ? (
+                <NoResult />
+            ) : null}
+            {props.loading && (
+                <Box marginTop={2}>
+                    <AlbumsLoader />
+                </Box>
+            )}
+        </Grid>
+    );
 }

--- a/app/src/hooks/usePlaylist.tsx
+++ b/app/src/hooks/usePlaylist.tsx
@@ -1,74 +1,185 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useFetchTidal } from "src/hooks/useFetchTidal";
 
 import { TIDAL_ITEMS_PER_PAGE } from "../contants";
 import { PlaylistType, TidalPagedListType, TrackType } from "../types";
 
+type SortField = "dateAdded" | "title" | "duration";
+type SortDirection = "asc" | "desc";
+
 type PlaylistContextType = {
-  loading: boolean;
-  playlist: PlaylistType | undefined;
-  tracks: TrackType[] | undefined;
-  page: number;
-  total: number;
-  actions: {
-    queryPlaylist: () => void;
-    setPage: (page: number) => void;
-  };
+	loading: boolean;
+	playlist: PlaylistType | undefined;
+	tracks: TrackType[] | undefined;
+	page: number;
+	total: number;
+	sortField: SortField;
+	sortDirection: SortDirection;
+	actions: {
+		queryPlaylist: () => void;
+		setPage: (page: number) => void;
+		setSort: (field: SortField, direction: SortDirection) => void;
+	};
 };
 
-export const usePlaylist = (id: string | undefined): PlaylistContextType => {
-  const [loading, setLoading] = useState<boolean>(false);
-  const [playlist, setPlaylist] = useState<PlaylistType>();
-  const [tracks, setTracks] = useState<TrackType[]>();
-  const [total, setTotal] = useState<number>(0);
-  const [page, setPage] = useState<number>(1);
+export const usePlaylist = (id?: string): PlaylistContextType => {
+	const { fetchTidal } = useFetchTidal();
 
-  const { fetchTidal } = useFetchTidal();
+	const [loading, setLoading] = useState(false);
+	const [playlist, setPlaylist] = useState<PlaylistType | undefined>(undefined);
+	const [allTracks, setAllTracks] = useState<TrackType[]>([]);
+	const [page, setPage] = useState(1);
+	const [total, setTotal] = useState(0);
 
-  async function queryPlaylist() {
-    setLoading(true);
+	// Default: treat API order as "date added (oldest → newest)"
+	// and show it inverted (newest first) on initial load.
+	const [sortField, setSortField] = useState<SortField>("dateAdded");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
 
-    const data_playlist = await fetchTidal<PlaylistType>(`/v1/playlists/${id}`);
+	const fetchAllTracks = useCallback(
+		async (playlistId: string): Promise<TrackType[]> => {
+			const collected: TrackType[] = [];
 
-    setPlaylist(data_playlist);
+			let offset = 0;
+			// Use a larger chunk size than the UI page size to avoid tons of API calls.
+			const limit = TIDAL_ITEMS_PER_PAGE * 5;
+			let totalItems: number | undefined;
+			// eslint-disable-next-line no-constant-condition
+			while (true) {
+				const data = await fetchTidal<
+					TidalPagedListType<{ item: TrackType }>
+				>(
+					`/v1/playlists/${playlistId}/items`,
+					{},
+					{ limit, offset },
+				);
 
-    const data_tracks = await fetchTidal<
-      TidalPagedListType<{ item: TrackType }>
-    >(
-      `/v1/playlists/${id}/items`,
-      {},
-      {
-        limit: TIDAL_ITEMS_PER_PAGE,
-        offset: (page - 1) * TIDAL_ITEMS_PER_PAGE,
-      },
-    );
+				const items = data?.items?.map((p) => p.item) ?? [];
+				collected.push(...items);
 
-    if (data_tracks) {
-    // Replace the current page of tracks instead of appending
-    setTracks(data_tracks.items.map((playlist) => playlist.item));
-    setTotal(data_tracks.totalNumberOfItems);
-	}
-    setLoading(false);
-  }
+				totalItems =
+					data?.totalNumberOfItems ??
+					(data as any)?.total ??
+					totalItems ??
+					0;
 
-	useEffect(() => {
-		if (!id) return;
-	
-		// Clear current tracks before fetching the new page
-		setTracks(undefined);
-		queryPlaylist();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [id, page]);
+				if (!items.length || collected.length >= (totalItems ?? 0)) {
+					break;
+				}
 
-  return {
-    playlist,
-    tracks,
-    total,
-    page,
-    loading,
-    actions: {
-      queryPlaylist,
-      setPage,
-    },
-  };
+				offset += limit;
+			}
+
+			setTotal(totalItems ?? collected.length);
+			return collected;
+		},
+		[fetchTidal],
+	);
+
+	const queryPlaylist = useCallback(async () => {
+		if (!id) {
+			setPlaylist(undefined);
+			setAllTracks([]);
+			setTotal(0);
+			return;
+		}
+
+		setLoading(true);
+		try {
+			const pl = await fetchTidal<PlaylistType>(`/v1/playlists/${id}`);
+			setPlaylist(pl);
+
+			// Full track list (fetched in chunks) — used for global sorting + paging
+			const tracks = await fetchAllTracks(id);
+			setAllTracks(tracks);
+		} catch (error) {
+			console.error("Error fetching playlist", error);
+			setPlaylist(undefined);
+			setAllTracks([]);
+			setTotal(0);
+		} finally {
+			setLoading(false);
+		}
+	}, [id, fetchTidal, fetchAllTracks]);
+
+  // Reload playlist whenever ID changes
+  useEffect(() => {
+    if (!id) return;
+    setPage(1);
+    void queryPlaylist();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+	/**
+	 * Apply sorting to the full track list.
+	 * - "dateAdded": use original playlist order, flip for desc
+	 * - "title": A–Z / Z–A
+	 * - "duration": short→long / long→short
+	 */
+	const sortedTracks = useMemo(() => {
+		const items = [...allTracks];
+		if (!items.length) return items;
+
+		if (sortField === "title") {
+			items.sort((a, b) =>
+				(a.title || "").localeCompare(b.title || "", undefined, {
+					sensitivity: "base",
+				}),
+			);
+		} else if (sortField === "duration") {
+			items.sort((a, b) => (a.duration || 0) - (b.duration || 0));
+		} else {
+			// "dateAdded": keep API order as-is for ASC
+			// (TIDAL returns tracks in "oldest added → newest added")
+		}
+
+		// For any sort mode, DESC just reverses the ASC ordering.
+		if (sortDirection === "desc") {
+			items.reverse();
+		}
+
+		return items;
+	}, [allTracks, sortField, sortDirection]);
+
+	/**
+	 * Slice sortedTracks into the current page.
+	 */
+	const pagedTracks = useMemo(() => {
+		if (!sortedTracks.length) return [] as TrackType[];
+
+		const start = (page - 1) * TIDAL_ITEMS_PER_PAGE;
+		const end = start + TIDAL_ITEMS_PER_PAGE;
+
+		return sortedTracks.slice(start, end);
+	}, [sortedTracks, page]);
+
+	const handleSetPage = useCallback((newPage: number) => {
+		setPage(newPage);
+	}, []);
+
+	const handleSetSort = useCallback(
+		(field: SortField, direction: SortDirection) => {
+			setSortField(field);
+			setSortDirection(direction);
+			// Go back to page 1 when sort changes so the user
+			// lands at the top of the new ordering.
+			setPage(1);
+		},
+		[],
+	);
+
+	return {
+		loading,
+		playlist,
+		tracks: pagedTracks,
+		page,
+		total,
+		sortField,
+		sortDirection,
+		actions: {
+			queryPlaylist,
+			setPage: handleSetPage,
+			setSort: handleSetSort,
+		},
+	};
 };

--- a/app/src/hooks/usePlaylist.tsx
+++ b/app/src/hooks/usePlaylist.tsx
@@ -44,19 +44,21 @@ export const usePlaylist = (id: string | undefined): PlaylistContextType => {
     );
 
     if (data_tracks) {
-      setTracks([
-        ...(tracks || ([] as TrackType[])),
-        ...data_tracks.items.map((playlist) => playlist.item),
-      ]);
-      setTotal(data_tracks.totalNumberOfItems);
-    }
+    // Replace the current page of tracks instead of appending
+    setTracks(data_tracks.items.map((playlist) => playlist.item));
+    setTotal(data_tracks.totalNumberOfItems);
+	}
     setLoading(false);
   }
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (id) queryPlaylist();
-  }, [id, page]);
+	useEffect(() => {
+		if (!id) return;
+	
+		// Clear current tracks before fetching the new page
+		setTracks(undefined);
+		queryPlaylist();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [id, page]);
 
   return {
     playlist,

--- a/app/src/pages/PagePlaylist.tsx
+++ b/app/src/pages/PagePlaylist.tsx
@@ -1,5 +1,12 @@
 import { useParams } from "react-router-dom";
-import { Box, Container } from "@mui/material";
+import {
+  Box,
+  Container,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
 import PagerButton from "src/components/Buttons/PagerButton";
 import PlaylistHeader from "src/components/Headers/Playlist";
 import ModuleLoader from "src/components/Skeletons/ModuleLoader";
@@ -9,7 +16,7 @@ import { usePlaylist } from "src/hooks/usePlaylist";
 
 export default function PagePlaylist() {
   const { id } = useParams();
-  const { loading, playlist, tracks, actions, page, total } = usePlaylist(id);
+  const { loading, playlist, tracks, actions, page, total, sortField, sortDirection } = usePlaylist(id);
 
   if (!loading && !playlist) {
     return <NoResult />;
@@ -19,8 +26,42 @@ export default function PagePlaylist() {
     <Container maxWidth="lg">
       {!playlist && loading && <ModuleLoader />}
       {playlist ? (
-        <Box mb={2}>
+        <Box
+          mb={2}
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          flexWrap="wrap"
+          gap={2}
+        >
           <PlaylistHeader playlist={playlist} />
+          <FormControl size="small" sx={{ minWidth: 220 }}>
+            <InputLabel id="playlist-sort-label">Sort by</InputLabel>
+            <Select
+              labelId="playlist-sort-label"
+              label="Sort by"
+              value={`${sortField}-${sortDirection}`}
+              onChange={(e) => {
+                const [field, direction] = (e.target.value as string).split("-");
+                actions.setSort(field as any, direction as any);
+              }}
+            >
+              <MenuItem value="dateAdded-desc">
+                Date added (newest first)
+              </MenuItem>
+              <MenuItem value="dateAdded-asc">
+                Date added (oldest first)
+              </MenuItem>
+              <MenuItem value="title-asc">Title (A–Z)</MenuItem>
+              <MenuItem value="title-desc">Title (Z–A)</MenuItem>
+              <MenuItem value="duration-asc">
+                Duration (short → long)
+              </MenuItem>
+              <MenuItem value="duration-desc">
+                Duration (long → short)
+              </MenuItem>
+            </Select>
+          </FormControl>
         </Box>
       ) : null}
 

--- a/app/src/provider/SearchProvider.tsx
+++ b/app/src/provider/SearchProvider.tsx
@@ -8,143 +8,148 @@ import { TidalResponseType } from "../types";
 import { useConfigProvider } from "./ConfigProvider";
 
 type SearchContextType = {
-  searchResults: TidalResponseType;
-  keywords: string | undefined;
-  loading: boolean;
-  page: number;
-  actions: {
-    setPage: (page: number) => void;
-    runSearch: (keywords: string) => void;
-    queryTidal: (query: string, page: number) => void;
-  };
+	searchResults: TidalResponseType;
+	keywords: string | undefined;
+	loading: boolean;
+	page: number;
+	actions: {
+		setPage: (page: number) => void;
+		runSearch: (keywords: string) => void;
+		// keep the original type signature for compatibility
+		queryTidal: (query: string, page: number) => void;
+	};
 };
 
-const SearchContext = React.createContext<SearchContextType>(
-  {} as SearchContextType,
-);
+const SearchContext = React.createContext<SearchContextType>({} as SearchContextType);
 
 export function SearchProvider({ children }: { children: ReactNode }) {
-  const [loading, setLoading] = useState<boolean>(false);
-  const [page, setPage] = useState<number>(1);
-  const [keywords, setKeywords] = useState<string>();
-  const { config } = useConfigProvider();
+	const [loading, setLoading] = useState<boolean>(false);
+	const [page, setPage] = useState<number>(1);
+	const [keywords, setKeywords] = useState<string>();
+	const { config } = useConfigProvider();
 
-  const [searchResults, setSearchResults] = useState<TidalResponseType>(
-    {} as TidalResponseType,
-  );
+	const [searchResults, setSearchResults] = useState<TidalResponseType>({} as TidalResponseType);
 
-  const params = useParams();
+	const params = useParams();
 
-  const { fetchTidal } = useFetchTidal();
+	const { fetchTidal } = useFetchTidal();
 
-  async function runSearch(searchString: string) {
-    setLoading(true);
-    await queryTidal(searchString);
-    setLoading(false);
-  }
+	async function runSearch(searchString: string) {
+		setLoading(true);
+		await queryTidal(searchString);
+		setLoading(false);
+	}
 
-  async function queryTidal(query: string) {
-    const results = await fetchTidal<TidalResponseType>(
-      "/v1/search",
-      {},
-      {
-        query: query,
-        offset: (page - 1) * TIDAL_ITEMS_PER_PAGE,
-        limit: TIDAL_ITEMS_PER_PAGE,
-      },
-    );
+	// NOTE: keep the original signature (only 'query' arg) for compatibility with callers.
+	async function queryTidal(query: string) {
+		const results = await fetchTidal<TidalResponseType>(
+			"/v1/search",
+			{},
+			{
+				query: query,
+				offset: (page - 1) * TIDAL_ITEMS_PER_PAGE,
+				limit: TIDAL_ITEMS_PER_PAGE,
+			},
+		);
 
-    const clone = { ...searchResults };
-    const data = {
-      albums: {
-        ...results?.albums,
-        items: [
-          ...(page > 1 ? clone?.albums?.items || [] : []),
-          ...(results?.albums?.items || []),
-        ],
-      },
-      artists: {
-        ...results?.artists,
-        items: [
-          ...(page > 1 ? clone?.artists?.items || [] : []),
-          ...(results?.artists?.items || []),
-        ],
-      },
-      tracks: {
-        ...results?.tracks,
-        items: [
-          ...(page > 1 ? clone?.tracks?.items || [] : []),
-          ...(results?.tracks?.items || []),
-        ],
-      },
-      playlists: {
-        ...results?.playlists,
-        items: [
-          ...(page > 1 ? clone?.playlists?.items || [] : []),
-          ...(results?.playlists?.items || []),
-        ],
-      },
-      videos: {
-        ...results?.videos,
-        items: [
-          ...(page > 1 ? clone?.videos?.items || [] : []),
-          ...(results?.videos?.items || []),
-        ],
-      },
-    };
+		// IMPORTANT: Replace (do not append) so page navigation shows the current slice only.
+		const data = {
+			albums: {
+				...results?.albums,
+				items: results?.albums?.items || [],
+				// keep if the API provides it; harmless if the type doesn't require it
+				totalNumberOfItems:
+					results?.albums?.totalNumberOfItems ??
+					(results as any)?.albums?.total ??
+					0,
+			},
+			artists: {
+				...results?.artists,
+				items: results?.artists?.items || [],
+				totalNumberOfItems:
+					results?.artists?.totalNumberOfItems ??
+					(results as any)?.artists?.total ??
+					0,
+			},
+			tracks: {
+				...results?.tracks,
+				items: results?.tracks?.items || [],
+				totalNumberOfItems:
+					results?.tracks?.totalNumberOfItems ??
+					(results as any)?.tracks?.total ??
+					0,
+			},
+			playlists: {
+				...results?.playlists,
+				items: results?.playlists?.items || [],
+				totalNumberOfItems:
+					results?.playlists?.totalNumberOfItems ??
+					(results as any)?.playlists?.total ??
+					0,
+			},
+			videos: {
+				...results?.videos,
+				items: results?.videos?.items || [],
+				totalNumberOfItems:
+					results?.videos?.totalNumberOfItems ??
+					(results as any)?.videos?.total ??
+					0,
+			},
+		};
 
-    setSearchResults(data as TidalResponseType);
-  }
+		setSearchResults(data as TidalResponseType);
+	}
 
-  // Fetch on page change
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (keywords) runSearch(keywords);
-  }, [page]);
+	// Fetch on page change
+	useEffect(() => {
+		// eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/rules-of-hooks, react-hooks/set-state-in-effect
+		if (keywords) runSearch(keywords);
+	}, [page]);
 
-  useEffect(() => {
-    if (keywords) {
-      // window.scrollTo(0, 0);
+	// Reset results + page when the keyword changes
+	useEffect(() => {
+		if (keywords) {
+			// eslint-disable-next-line react-hooks/set-state-in-effect
+			setSearchResults({} as TidalResponseType);
+			if (page > 1) {
+				setPage(1);
+				return;
+			}
 
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setSearchResults({} as TidalResponseType);
-      if (page > 1) {
-        setPage(1);
-        return;
-      }
+			runSearch(keywords);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [keywords]);
 
-      runSearch(keywords);
-    }
-  }, [keywords]);
+	// If url query exists on load
+	useEffect(() => {
+		if (!params.keywords || !config) {
+			// eslint-disable-next-line react-hooks/set-state-in-effect
+			setKeywords(undefined);
+			return;
+		}
 
-  // If url query exists on load
-  useEffect(() => {
-    if (!params.keywords || !config) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setKeywords(undefined);
-      return;
-    }
+		setKeywords(params.keywords);
+	}, [params, config]);
 
-    setKeywords(params.keywords);
-  }, [params, config]);
+	const value = {
+		searchResults,
+		loading,
+		keywords,
+		page,
+		actions: {
+			setPage,
+			// keep assignment compatible with the original actions type
+			queryTidal: (q: string) => {
+				void queryTidal(q);
+			},
+			runSearch,
+		},
+	};
 
-  const value = {
-    searchResults,
-    loading,
-    keywords,
-    page,
-    actions: {
-      setPage,
-      queryTidal,
-      runSearch,
-    },
-  };
-
-  return (
-    <SearchContext.Provider value={value}>{children}</SearchContext.Provider>
-  );
+	return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>;
 }
 
 export const useSearchProvider = () => {
-  return useContext(SearchContext);
+	return useContext(SearchContext);
 };


### PR DESCRIPTION
## Key Features Added:
- Global sorting modes for playlists:
  - Date added (newest first) (default)
  - Date added (oldest first)
  - Title (A–Z / Z–A)
  - Duration (short → long / long → short)

- Full playlist is now fetched in safe-sized chunks once per playlist ID, allowing sorting across the entire dataset rather than per page.

- Client-side pagination now operates on the sorted playlist:

- Page changes only slice from the sorted list

- No additional API calls per page beyond the initial chunked load
  - (Takes a second for bigger playlists)

- New “Sort By” dropdown in the playlist page UI for user-facing sorting controls.