### PR TITLE
fix in navidrome search counts

### DIFF
--- a/app/src/components/Buttons/NavidromeSearchButton.tsx
+++ b/app/src/components/Buttons/NavidromeSearchButton.tsx
@@ -69,7 +69,9 @@ export const NavidromeSearchButton = ({
         }
 
         const artistsCount = searchResult.artist
-          ? searchResult.artist.filter((a: any) => a.name === query).length
+          ? (searchResult.artist as { name: string }[]).filter(
+              (a) => a.name === query,
+            ).length
           : 0;
         const albumsCount = searchResult.album?.length || 0;
         const tracksCount = searchResult.song?.length || 0;


### PR DESCRIPTION
I had it in docker from previous navidrome tests, testing the search button on it, I saw that it only showed 20 items from albums and songs, plus it showed me many more items from artists due to the collaboration songs from the artist's own albums. So I think that's fine.