### PR TITLE
fix(tiddl): surface tiddl stderr on token refresh failure

### DIFF
--- a/api/src/services/tiddl.ts
+++ b/api/src/services/tiddl.ts
@@ -276,6 +276,9 @@ export async function refreshTidalToken(): Promise<void> {
       },
     });
 
+    const stderrChunks: Buffer[] = [];
+    refreshProcess.stderr?.on("data", (chunk) => stderrChunks.push(chunk));
+
     refreshProcess.on("close", async (code) => {
       if (code === 0) {
         console.log(
@@ -284,7 +287,10 @@ export async function refreshTidalToken(): Promise<void> {
         // Wait 500ms to ensure file is written to disk before resolving
         await new Promise((r) => setTimeout(r, 500));
       } else {
-        console.log(`⚠️ [TIDDL] Token refresh exited with code ${code}`);
+        const err = Buffer.concat(stderrChunks).toString("utf-8").trim();
+        console.log(
+          `⚠️ [TIDDL] Token refresh exited with code ${code}${err ? `:\n${err}` : ""}`,
+        );
       }
       resolve();
     });


### PR DESCRIPTION
Fixes #804

### Problem
`refreshTidalToken()` spawns `tiddl auth refresh` but never reads the process's stderr. On a non-zero exit it logs only `⚠️ [TIDDL] Token refresh exited with code ${code}`, discarding the Python traceback tiddl wrote to stderr. Any tiddl-side failure (e.g. a Pydantic `ValidationError` on `config.toml` that crashes tiddl at import time) therefore surfaces as a generic "exit code 1" that misleadingly looks like a token/network problem.

### Fix
Capture the child's stderr and append it to the non-zero-exit log line, so the actual error is visible. The success path is unchanged. This matches the stderr-forwarding the other spawn sites in this file already do.

### Verify
Put an invalid value in `config.toml` so tiddl crashes at import, then trigger a token refresh. The log line now reads `⚠️ [TIDDL] Token refresh exited with code 1:` followed by the traceback instead of just the bare code.

> Note: the report also mentions `deleteTiddlConfig` dropping stderr; that's tracked separately (see #805) and intentionally out of scope here to keep this fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)