### PR TITLE
fix(api): force tiddl auth logout and verify exit status when revoking token

### DIFF
--- a/api/src/services/tiddl.ts
+++ b/api/src/services/tiddl.ts
@@ -254,12 +254,20 @@ export function tidalToken(req: Request, res: Response) {
 
 export function deleteTiddlConfig() {
   try {
-    spawnSync(TIDDL_BINARY, ["auth", "logout"], {
+    const result = spawnSync(TIDDL_BINARY, ["auth", "logout", "--force"], {
       env: { ...process.env },
+      encoding: "utf-8",
     });
-    console.log(
-      `✅ [TIDDL] Auth tokens deleted from ${CONFIG_PATH}/.tiddl/auth.json`,
-    );
+    if (result.status === 0) {
+      console.log(
+        `✅ [TIDDL] Auth tokens deleted from ${CONFIG_PATH}/.tiddl/auth.json`,
+      );
+    } else {
+      console.error(
+        `❌ [TIDDL] tiddl auth logout --force exited with code ${result.status}` +
+          (result.stderr ? `:\n${result.stderr.trim()}` : ""),
+      );
+    }
   } catch (e) {
     console.error("❌ [TIDDL] Error deleting tiddl config:", e);
   }


### PR DESCRIPTION
Fixes #805

### Problem
`deleteTiddlConfig()` backs the UI's "Revoke Tidal token" button. It runs `tiddl auth logout` via `spawnSync` and then logs success unconditionally. Two defects make the button a no-op precisely when it's needed most (token already expired/revoked):

1. `tiddl auth logout` (without `--force`) first attempts Tidal's server-side logout using the current token. When that token is already expired/revoked, tiddl refuses to clear the local session and returns **without** removing `auth.json`.
2. The `✅ [TIDDL] Auth tokens deleted ...` line fires unconditionally. `spawnSync` only throws on spawn-level failures (e.g. `ENOENT`), not on a non-zero exit, and `status` was never inspected — so even when tiddl exits non-zero without touching `auth.json`, the journal reports success and the UI keeps showing the user as authenticated.

### Fix
- Pass `--force` so tiddl always clears the local session regardless of the server-side logout result (the behavior the button promises).
- Gate the success log on `status === 0`, and surface stderr on failure.

### Verify
Authenticate, then expire/revoke the token (or hand-edit `auth.json` so the refresh token is invalid). Click **Revoke Tidal token**. `auth.json` is now actually removed and the UI shows "No Tidal token found !". The ✅ line is logged only on exit 0; otherwise a ❌ line with the code + stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)