### PR TITLE
docs: fix SABnzbd URL Base in Lidarr integration guide

### DIFF
--- a/docs/LIDARR_INTEGRATION.md
+++ b/docs/LIDARR_INTEGRATION.md
@@ -63,7 +63,7 @@ Add Tidarr as a **SABnzbd** download client:
 | **Enable**   | ✅ Enabled                         |
 | **Host**     | `your-tidarr-url`                  |
 | **Port**     | `8484`                             |
-| **URL Base** | `/api/sabnzbd/api`                 |
+| **URL Base** | `/api/sabnzbd`                     |
 | **API Key**  | Get from Tidarr (see below)        |
 | **Category** | `music` (optional but recommended) |
 


### PR DESCRIPTION
Fixes #806

### Problem
The Lidarr integration guide instructs setting the SABnzbd download client **URL Base** to `/api/sabnzbd/api`. Lidarr appends `/api` to the URL Base itself, so this produces requests to `/api/sabnzbd/api/api`, which 404s and falls through to the SPA `index.html`. Lidarr's connection test then fails with a JSON parse error on the leading `<`.

### Fix
Use `/api/sabnzbd` so Lidarr requests `/api/sabnzbd/api`, matching the existing handler (`router.get("/sabnzbd/api", ...)` in `api/src/routes/lidarr.ts`).

The architecture diagram further down (which shows the real server endpoint `/api/sabnzbd/api`) is correct and left unchanged.

### Verify
Configure a Lidarr SABnzbd download client with URL Base `/api/sabnzbd` and click **Test** — it succeeds instead of failing with the JSON parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)