### PR TITLE
feat(api): add per-track post-processing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,10 +550,11 @@ Tidarr can be integrated with Lidarr as both a Newznab indexer and a SABnzbd dow
 
 ### Custom Processing Scripts
 
-Tidarr supports two custom shell scripts during the post-processing pipeline:
+Tidarr supports three custom shell scripts during the post-processing pipeline:
 
-- **`custom-script.sh`** - Runs **before** files are moved to the library
-- **`custom-post-script.sh`** - Runs **after** files are moved to the library
+- **`custom-track-script.sh`** - Runs once per audio file after tagging
+- **`custom-script.sh`** - Runs once per item before files are moved to the library
+- **`custom-post-script.sh`** - Runs once per item after files are moved to the library
 
 You can also install additional Python packages by placing a **`requirements.txt`** file in your root config folder.
 

--- a/api/src/processing/post-processing/tidarr-post-processor.ts
+++ b/api/src/processing/post-processing/tidarr-post-processor.ts
@@ -4,6 +4,7 @@ import { beets } from "../../services/beets";
 import {
   executeCustomScript,
   executePostScript,
+  executeTrackScripts,
 } from "../../services/custom-scripts";
 import { gotifyPush } from "../../services/gotify";
 import { jellyfinUpdate } from "../../services/jellyfin";
@@ -87,6 +88,9 @@ export async function postProcessTidarr(
 
   // Set permissions
   await setPermissions(item);
+
+  // Emit one completion hook per fully processed track
+  await executeTrackScripts(item);
 
   // Execute custom script after tagging, before files are moved to the library
   await executeCustomScript(item);

--- a/api/src/processing/post-processing/tidarr-post-processor.ts
+++ b/api/src/processing/post-processing/tidarr-post-processor.ts
@@ -76,9 +76,6 @@ export async function postProcessTidarr(
     return;
   }
 
-  // Execute custom script if exists
-  await executeCustomScript(item);
-
   // Update m3u item path (playlist/mix only — favorite_tracks M3U is written directly to library after move)
   await replacePathInM3U(item);
 
@@ -90,6 +87,9 @@ export async function postProcessTidarr(
 
   // Set permissions
   await setPermissions(item);
+
+  // Execute custom script after tagging, before files are moved to the library
+  await executeCustomScript(item);
 
   // Keep trace of folders processed
   const foldersToScan = await getFolderToScan(item.id);

--- a/api/src/services/custom-scripts.ts
+++ b/api/src/services/custom-scripts.ts
@@ -18,6 +18,26 @@ interface ScriptConfig {
   scriptName: string;
 }
 
+const AUDIO_EXTENSIONS = new Set([
+  ".aac",
+  ".aif",
+  ".aiff",
+  ".ape",
+  ".flac",
+  ".m4a",
+  ".mp2",
+  ".mp3",
+  ".mp4",
+  ".oga",
+  ".ogg",
+  ".opus",
+  ".snd",
+  ".tak",
+  ".wav",
+  ".wma",
+  ".wv",
+]);
+
 /**
  * Generic script runner that handles chmod, spawn, logging and error handling.
  */
@@ -104,6 +124,48 @@ export async function executeCustomScript(
     logPrefix: "CUSTOM SCRIPT",
     scriptName: "custom script",
   });
+}
+
+/**
+ * Executes custom-track-script.sh once for each fully processed audio file.
+ */
+export async function executeTrackScripts(
+  item: ProcessingItemType,
+): Promise<void> {
+  const scriptPath = path.join(CONFIG_PATH, "custom-track-script.sh");
+  if (
+    !fs.existsSync(scriptPath) ||
+    ["video", "artist_videos", "favorite_videos"].includes(item.type)
+  ) {
+    return;
+  }
+
+  const itemProcessingPath = `${PROCESSING_PATH}/${item.id}`;
+  const tracks = fs
+    .readdirSync(itemProcessingPath, { recursive: true, withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        AUDIO_EXTENSIONS.has(path.extname(entry.name).toLowerCase()),
+    )
+    .map((entry) => path.join(entry.parentPath, entry.name));
+
+  for (const trackPath of tracks) {
+    await runScript(item, {
+      scriptPath,
+      cwd: path.dirname(trackPath),
+      env: {
+        PROCESSING_PATH: itemProcessingPath,
+        TRACK_PATH: trackPath,
+        TRACK_RELATIVE_PATH: path.relative(itemProcessingPath, trackPath),
+        ITEM_TYPE: item.type,
+        ITEM_URL: item.url,
+        ITEM_NAME: item.title,
+      },
+      logPrefix: "TRACK SCRIPT",
+      scriptName: `custom track script for ${path.basename(trackPath)}`,
+    });
+  }
 }
 
 /**

--- a/docs/CUSTOM_SCRIPT_DOCUMENTATION.md
+++ b/docs/CUSTOM_SCRIPT_DOCUMENTATION.md
@@ -1,16 +1,44 @@
 # Custom Script Documentation
 
-Tidarr supports two custom shell scripts that allow you to perform custom operations during the post-processing pipeline:
+Tidarr supports three custom shell scripts that allow you to perform custom operations during the post-processing pipeline:
 
-1. **`custom-script.sh`** - Runs **before** files are moved to the library
-2. **`custom-post-script.sh`** - Runs **after** files are moved to the library
+1. **`custom-track-script.sh`** - Runs once per audio file after tagging
+2. **`custom-script.sh`** - Runs once per item before files are moved to the library
+3. **`custom-post-script.sh`** - Runs once per item after files are moved to the library
 
 ---
 
 ## Pipeline Order
 
 ```
-Download → Beets → ReplayGain → Permissions → custom-script.sh → Move to Library → custom-post-script.sh → Plex/Jellyfin/Navidrome Scan → Notifications
+Download → Beets → ReplayGain → Permissions → custom-track-script.sh (per track) → custom-script.sh → Move to Library → custom-post-script.sh → Plex/Jellyfin/Navidrome Scan → Notifications
+```
+
+---
+
+## Per-Track Script: `custom-track-script.sh`
+
+The optional `custom-track-script.sh` runs once for every audio file after
+Tidarr finishes Beets, ReplayGain, and permission processing. Album and playlist
+downloads therefore emit one hook per track, while the files are still in the
+processing directory.
+
+**Available environment variables:**
+
+```bash
+PROCESSING_PATH     # Root processing directory for the queued item
+TRACK_PATH          # Absolute path to the completed audio file
+TRACK_RELATIVE_PATH # Track path relative to PROCESSING_PATH
+ITEM_TYPE           # Queued item type
+ITEM_URL            # Tidal URL of the queued item
+ITEM_NAME           # Human-readable name of the queued item
+```
+
+**Example script:**
+
+```bash
+#!/bin/sh
+printf '%s\n' "$TRACK_PATH" >> /shared/completed-tracks.queue
 ```
 
 ---
@@ -137,7 +165,7 @@ echo "Post-processing complete!"
 
 ## Important Notes
 
-- Both scripts are **optional** - Tidarr works normally without them
+- All scripts are **optional** - Tidarr works normally without them
 - Scripts are made executable automatically (chmod +x is applied)
 - Script errors won't stop the download pipeline - processing continues regardless
 - All stdout/stderr output is logged and visible in the download terminal dialog


### PR DESCRIPTION
## Summary

- add an optional `custom-track-script.sh` hook that runs once per completed audio file
- expose `TRACK_PATH`, `TRACK_RELATIVE_PATH`, and the existing item context to the hook
- run per-track and item hooks after Beets, ReplayGain, and permissions, but before moving files
- document the per-track contract and align the existing item hook with the documented pipeline

Album and playlist jobs can now notify external workers once per fully processed track without changing the existing item-level `custom-script.sh` behavior. The hooks run after album-wide tagging is complete, ensuring workers never race Tidarr while it is still writing tags.

## Tests

- `yarn api-build`
- `yarn eslint` (passes with 8 pre-existing React hook warnings)