### PR TITLE
fix(api): run custom script after tagging

### DIFF
--- a/api/src/processing/post-processing/tidarr-post-processor.ts
+++ b/api/src/processing/post-processing/tidarr-post-processor.ts
@@ -76,9 +76,6 @@ export async function postProcessTidarr(
     return;
   }
 
-  // Execute custom script if exists
-  await executeCustomScript(item);
-
   // Update m3u item path (playlist/mix only — favorite_tracks M3U is written directly to library after move)
   await replacePathInM3U(item);
 
@@ -90,6 +87,9 @@ export async function postProcessTidarr(
 
   // Set permissions
   await setPermissions(item);
+
+  // Execute custom script after tagging, before files are moved to the library
+  await executeCustomScript(item);
 
   // Keep trace of folders processed
   const foldersToScan = await getFolderToScan(item.id);


### PR DESCRIPTION
## Summary

Move `custom-script.sh` after Beets, ReplayGain, and permission processing while keeping it before files are moved to the library.

## Rationale

The documented pipeline places `custom-script.sh` after Beets, ReplayGain, and permissions, but the implementation currently invokes it before those steps.

External post-processing scripts can therefore observe or modify files before Tidarr has finished writing tags. Moving the hook to its documented position makes it a reliable signal that Tidarr's tagging work is complete while preserving access to the processing directory.

## Testing

- `yarn api-build`