### PR TITLE
feat(front,api): support MAX and Atmos with separate TIDAL profiles

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,7 +10,7 @@ jobs:
   eslint:
     name: Run eslint scanning
     runs-on: ubuntu-latest
-    
+
     permissions:
       contents: read
       security-events: write
@@ -31,4 +31,7 @@ jobs:
       - name: Run ESLINT
         run: |
           yarn eslint
-      
+
+      - name: Run API unit tests
+        run: |
+          yarn api-test

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,16 @@
 .vscode
 *.pem
 
+# local runtime configuration and credentials
+/.tidarr-api-key
+/.tiddl/
+/.tiddl-atmos/
+/beets-config.yml
+/beets/
+/custom.css
+/queue.json
+/sync_list.json
+
 #ai
 .continue
 AGENT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Tidarr notable changes.
 
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) format.
 
+## Unreleased
+### 🐛 Fixed
+- [API] Use Hi-Res PKCE authentication so Atmos-tagged releases can return their stereo stream and MAX requests can return available Hi-Res FLAC
+- [API] Refresh PKCE tokens with the same TIDAL client identity before starting Tiddl downloads
+- [API] Keep a separate device-authenticated profile for Dolby Atmos downloads so Atmos and MAX Hi-Res can coexist
+
 ## 📦 1.2.6
 ### 🐛 Fixed
 - [Lidarr] Batch download is now applied to Lidarr integration #860

--- a/README.md
+++ b/README.md
@@ -154,7 +154,25 @@ docker run  \
 
 (if no `tiddl.json` file provided) :
 
-Authorize your device using the UI token dialog
+Authorize your account using the UI token dialog:
+
+1. Open the TIDAL login link.
+2. Sign in. TIDAL redirects to an “Oops” page; this is expected.
+3. Copy the complete URL from the browser address bar and paste it back into
+   Tidarr.
+
+Tidarr uses TIDAL's PKCE client for this login. Unlike the legacy device token,
+it can request stereo when an Atmos variant exists and can request available
+MAX/Hi-Res FLAC streams. Existing installations using a legacy token are asked
+to authenticate once again after upgrading. Tidarr preserves that legacy token
+as a separate Dolby Atmos profile and selects the correct profile from the
+Atmos filter. Fresh installations can add the second profile from **Settings →
+Tiddl configuration → Authenticate Atmos**.
+
+> [!NOTE]
+> The selected quality is a requested maximum. TIDAL can still return a lower
+> quality when the subscription, region, or selected release does not expose the
+> requested stream.
 
 **or**
 
@@ -167,6 +185,15 @@ docker compose exec -it -e tidarr tiddl auth login
 ```bash
 docker exec -it -e tidarr tiddl auth
 ```
+
+The CLI commands above use Tiddl's legacy device login and may be limited to
+16-bit LOSSLESS or receive Atmos playback responses. Tidarr uses that profile
+only for **Atmos only** and **Atmos allowed**; **No Atmos** uses the Hi-Res PKCE
+profile for reliable stereo selection and MAX quality.
+
+Because Tiddl uses one authentication profile for a complete download process,
+non-Atmos tracks processed with **Atmos allowed** can still be limited to
+legacy LOSSLESS instead of MAX.
 
 ## OPTIONS
 

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -12,6 +12,7 @@
 
 # production
 /dist
+/dist-test
 
 # misc
 .DS_Store

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "build": "npx tsc --project ./tsconfig.json",
+    "test": "npx tsc --project ./tsconfig.test.json && node dist-test/src/services/tidal-pkce.test.js",
     "start": "npx tsx --watch index.ts",
     "prod": "node ./dist/index.js",
     "find-deadcode": "ts-prune | (! grep -v 'used in module')",

--- a/api/src/processing/download/download-handler.ts
+++ b/api/src/processing/download/download-handler.ts
@@ -1,6 +1,6 @@
 import { Express } from "express";
 
-import { tidalDL } from "../../services/tiddl";
+import { ensureTidalTokenFresh, tidalDL } from "../../services/tiddl";
 import { ProcessingItemType } from "../../types";
 import { getArtistAlbums } from "../utils/artist-discography";
 import { getFavoriteAlbums } from "../utils/favorite-albums-to-queue";
@@ -76,6 +76,20 @@ export async function handleDownload(
       return;
     }
     item["url"] = `playlist/${playlistId}`;
+  }
+
+  try {
+    await ensureTidalTokenFresh(app, item);
+  } catch (error) {
+    item.status = "error";
+    item.loading = false;
+    logs(
+      item.id,
+      `❌ [TIDAL] Token refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    app.locals.processingStack.actions.updateItem(item);
+    onComplete(playlistId);
+    return;
   }
 
   // Start tiddl download

--- a/api/src/routes/config.ts
+++ b/api/src/routes/config.ts
@@ -3,7 +3,13 @@ import { Request, Response, Router } from "express";
 import { ensureAccessIsGranted } from "../helpers/auth";
 import { handleRouteError } from "../helpers/error-handler";
 import { get_tiddl_config } from "../helpers/get_tiddl_config";
-import { deleteTiddlConfig, tidalToken } from "../services/tiddl";
+import {
+  completePkceLogin,
+  hasAtmosAuth,
+  isPkceAuth,
+  startPkceLogin,
+} from "../services/tidal-pkce";
+import { deleteTiddlConfig, tidalAtmosToken } from "../services/tiddl";
 import { SettingsResponse } from "../types";
 
 const router = Router();
@@ -28,6 +34,9 @@ router.get(
         ...res.app.locals.config,
         noToken:
           !tiddl_config?.auth?.token || tiddl_config?.auth?.token?.length === 0,
+        requiresPkceAuth:
+          !!tiddl_config?.auth?.token && !isPkceAuth(tiddl_config.auth),
+        noAtmosToken: !hasAtmosAuth(),
         tiddl_config: tiddl_config,
         configErrors: configErrors.length > 0 ? configErrors : undefined,
       });
@@ -39,10 +48,28 @@ router.get(
 
 /**
  * GET /api/run-token
- * Run Tidal authentication flow (SSE endpoint)
+ * Deprecated legacy authentication endpoint.
  */
 router.get(
   "/run-token",
+  ensureAccessIsGranted,
+  (_req: Request, res: Response) => {
+    res.status(410).json({
+      message:
+        "This authentication endpoint was replaced by the Hi-Res PKCE and Atmos profile endpoints.",
+      pkceStart: "/api/token/pkce/start",
+      pkceComplete: "/api/token/pkce/complete",
+      atmosphere: "/api/token/atmos",
+    });
+  },
+);
+
+/**
+ * GET /api/token/atmos
+ * Run the device authorization used by TIDAL's Atmos-capable client profile.
+ */
+router.get(
+  "/token/atmos",
   ensureAccessIsGranted,
   async (req: Request, res: Response) => {
     try {
@@ -50,9 +77,56 @@ router.get(
       res.setHeader("Cache-Control", "no-cache");
       res.setHeader("Connection", "keep-alive");
       res.flushHeaders();
-      await tidalToken(req, res);
+      await tidalAtmosToken(req, res);
     } catch (error) {
-      handleRouteError(error, res, "run token authentication");
+      handleRouteError(error, res, "run Atmos token authentication");
+    }
+  },
+);
+
+/**
+ * GET /api/token/pkce/start
+ * Start a Hi-Res-capable TIDAL PKCE authentication flow.
+ */
+router.get(
+  "/token/pkce/start",
+  ensureAccessIsGranted,
+  (_req: Request, res: Response) => {
+    try {
+      res.status(200).json(startPkceLogin());
+    } catch (error) {
+      handleRouteError(error, res, "start TIDAL PKCE authentication");
+    }
+  },
+);
+
+/**
+ * POST /api/token/pkce/complete
+ * Exchange the redirected TIDAL URL for a refreshable Hi-Res token.
+ */
+router.post(
+  "/token/pkce/complete",
+  ensureAccessIsGranted,
+  async (req: Request, res: Response) => {
+    const { loginId, redirectUrl } = req.body || {};
+    if (typeof loginId !== "string" || typeof redirectUrl !== "string") {
+      res.status(200).json({
+        success: false,
+        message: "Both loginId and redirectUrl are required.",
+      });
+      return;
+    }
+
+    try {
+      await completePkceLogin(loginId, redirectUrl);
+      const { config: freshConfig } = get_tiddl_config();
+      req.app.locals.tiddlConfig = freshConfig;
+      res.status(200).json({ success: true, message: "Authenticated!" });
+    } catch (error) {
+      res.status(200).json({
+        success: false,
+        message: error instanceof Error ? error.message : String(error),
+      });
     }
   },
 );

--- a/api/src/services/tidal-pkce.test.ts
+++ b/api/src/services/tidal-pkce.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, test } from "node:test";
+
+import { TidalAuth } from "../types";
+
+import {
+  completePkceLogin,
+  createTidalProfilePaths,
+  getAtmosAuth,
+  getTiddlEnvironment,
+  isPkceAuth,
+  needsTokenRefresh,
+  preserveLegacyAuthForAtmos,
+  refreshPkceAuth,
+  selectTidalProfile,
+  startPkceLogin,
+  TIDAL_PKCE_CLIENT_ID,
+} from "./tidal-pkce";
+
+const temporaryDirectories: string[] = [];
+
+function createTemporaryProfile() {
+  const root = mkdtempSync(join(tmpdir(), "tidarr-pkce-test-"));
+  temporaryDirectories.push(root);
+  return createTidalProfilePaths(root);
+}
+
+function createAuth(overrides: Partial<TidalAuth> = {}): TidalAuth {
+  return {
+    token: "access-token",
+    refresh_token: "refresh-token",
+    expires_at: 2_000,
+    user_id: "123",
+    country_code: "IT",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("PKCE login", () => {
+  test("binds the authorization request to its returned OAuth state", () => {
+    const { loginId, loginUrl } = startPkceLogin();
+    const url = new URL(loginUrl);
+
+    assert.equal(url.origin, "https://login.tidal.com");
+    assert.equal(url.searchParams.get("state"), loginId);
+    assert.equal(url.searchParams.get("client_id"), TIDAL_PKCE_CLIENT_ID);
+    assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+    assert.ok(url.searchParams.get("code_challenge"));
+  });
+
+  test("rejects a missing or mismatched state before exchanging a code", async () => {
+    const { loginId } = startPkceLogin();
+
+    await assert.rejects(
+      completePkceLogin(
+        loginId,
+        "https://tidal.com/android/login/auth?code=test-code",
+      ),
+      /state is missing or does not match/,
+    );
+    await assert.rejects(
+      completePkceLogin(
+        loginId,
+        "https://tidal.com/android/login/auth?code=test-code&state=wrong",
+      ),
+      /state is missing or does not match/,
+    );
+  });
+
+  test("rejects authorization codes pasted from another redirect target", async () => {
+    const { loginId } = startPkceLogin();
+
+    await assert.rejects(
+      completePkceLogin(
+        loginId,
+        `https://example.com/android/login/auth?code=test-code&state=${loginId}`,
+      ),
+      /not the expected TIDAL authentication redirect/,
+    );
+  });
+});
+
+describe("TIDAL profile migration", () => {
+  test("preserves a legacy token and config as the Atmos profile", () => {
+    const paths = createTemporaryProfile();
+    const legacyAuth = createAuth();
+    mkdirSync(paths.hiresDirectory, { recursive: true });
+    writeFileSync(paths.authFile, JSON.stringify(legacyAuth));
+    writeFileSync(`${paths.hiresDirectory}/config.toml`, "[download]\n");
+
+    preserveLegacyAuthForAtmos(paths);
+
+    assert.deepEqual(getAtmosAuth(paths), legacyAuth);
+    assert.equal(
+      readFileSync(`${paths.atmosphereDirectory}/config.toml`, "utf-8"),
+      "[download]\n",
+    );
+    assert.equal(statSync(paths.atmosphereAuthFile).mode & 0o777, 0o600);
+  });
+
+  test("does not overwrite an existing Atmos token", () => {
+    const paths = createTemporaryProfile();
+    const existingAtmosAuth = createAuth({ token: "existing-atmos-token" });
+    mkdirSync(paths.hiresDirectory, { recursive: true });
+    mkdirSync(paths.atmosphereDirectory, { recursive: true });
+    writeFileSync(paths.authFile, JSON.stringify(createAuth()));
+    writeFileSync(paths.atmosphereAuthFile, JSON.stringify(existingAtmosAuth));
+    chmodSync(paths.atmosphereAuthFile, 0o600);
+
+    preserveLegacyAuthForAtmos(paths);
+
+    assert.deepEqual(getAtmosAuth(paths), existingAtmosAuth);
+  });
+
+  test("does not copy a PKCE token into the Atmos profile", () => {
+    const paths = createTemporaryProfile();
+    mkdirSync(paths.hiresDirectory, { recursive: true });
+    writeFileSync(
+      paths.authFile,
+      JSON.stringify(createAuth({ auth_type: "pkce", is_pkce: true })),
+    );
+
+    preserveLegacyAuthForAtmos(paths);
+
+    assert.equal(getAtmosAuth(paths), undefined);
+  });
+});
+
+describe("TIDAL profile selection and refresh", () => {
+  test("selects the correct profile for every Atmos filter", () => {
+    assert.equal(selectTidalProfile("none", true), "hires");
+    assert.equal(selectTidalProfile("only", true), "atmos");
+    assert.equal(selectTidalProfile("allow", true), "atmos");
+    assert.equal(selectTidalProfile("only", false), "hires");
+    assert.equal(selectTidalProfile("allow", false), "hires");
+  });
+
+  test("refreshes expired and soon-expiring tokens only", () => {
+    assert.equal(needsTokenRefresh(undefined, 1_000), false);
+    assert.equal(needsTokenRefresh(createAuth({ expires_at: 0 }), 1_000), true);
+    assert.equal(
+      needsTokenRefresh(createAuth({ expires_at: 1_900 }), 1_000),
+      true,
+    );
+    assert.equal(
+      needsTokenRefresh(createAuth({ expires_at: 1_901 }), 1_000),
+      false,
+    );
+  });
+
+  test("refreshes PKCE tokens with the original client identity", async () => {
+    const paths = createTemporaryProfile();
+    const auth = createAuth({ auth_type: "pkce", is_pkce: true });
+    mkdirSync(paths.hiresDirectory, { recursive: true });
+    writeFileSync(paths.authFile, JSON.stringify(auth));
+    let requestBody: URLSearchParams | undefined;
+
+    const refreshed = await refreshPkceAuth(auth, {
+      paths,
+      request: async (body) => {
+        requestBody = body;
+        return {
+          access_token: "refreshed-access-token",
+          expires_in: 3_600,
+        };
+      },
+    });
+
+    assert.equal(requestBody?.get("grant_type"), "refresh_token");
+    assert.equal(requestBody?.get("refresh_token"), auth.refresh_token);
+    assert.equal(requestBody?.get("client_id"), TIDAL_PKCE_CLIENT_ID);
+    assert.ok(requestBody?.get("client_secret"));
+    assert.equal(refreshed.token, "refreshed-access-token");
+    assert.equal(refreshed.refresh_token, auth.refresh_token);
+    assert.equal(
+      JSON.parse(readFileSync(paths.authFile, "utf-8")).token,
+      "refreshed-access-token",
+    );
+    assert.equal(statSync(paths.authFile).mode & 0o777, 0o600);
+  });
+
+  test("keeps PKCE credentials out of the Atmos environment", () => {
+    const paths = createTemporaryProfile();
+    const pkceAuth = createAuth({ auth_type: "pkce", is_pkce: true });
+    const hiresEnvironment = getTiddlEnvironment(pkceAuth, "hires", paths);
+    const atmosphereEnvironment = getTiddlEnvironment(pkceAuth, "atmos", paths);
+
+    const pkceCredentials = hiresEnvironment.TIDDL_AUTH?.split(";");
+    assert.equal(pkceCredentials?.[0], TIDAL_PKCE_CLIENT_ID);
+    assert.equal(pkceCredentials?.length, 2);
+    assert.ok(pkceCredentials?.[1]);
+    assert.equal(hiresEnvironment.TIDDL_PATH, paths.hiresDirectory);
+    assert.equal(atmosphereEnvironment.TIDDL_AUTH, undefined);
+    assert.equal(atmosphereEnvironment.TIDDL_PATH, paths.atmosphereDirectory);
+    assert.equal(isPkceAuth(pkceAuth), true);
+  });
+});

--- a/api/src/services/tidal-pkce.ts
+++ b/api/src/services/tidal-pkce.ts
@@ -1,0 +1,411 @@
+import { createHash, randomBytes } from "crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+} from "fs";
+import { mkdir, rename, writeFile } from "fs/promises";
+
+import { CONFIG_PATH } from "../../constants";
+import { TidalAuth } from "../types";
+
+const TIDAL_AUTH_URL = "https://auth.tidal.com/v1/oauth2/token";
+const TIDAL_LOGIN_URL = "https://login.tidal.com/authorize";
+const TIDAL_SESSION_URL = "https://api.tidal.com/v1/sessions";
+const TIDAL_PKCE_REDIRECT_URI = "https://tidal.com/android/login/auth";
+
+// Public client credentials used by python-tidal's Hi-Res PKCE flow:
+// https://github.com/tamland/python-tidal/blob/main/tidalapi/session.py
+export const TIDAL_PKCE_CLIENT_ID = "6BDSRdpK9hqEBTgU";
+const TIDAL_PKCE_CLIENT_SECRET = "xeuPmY7nbpZ9IIbLAcQ93shka1VNheUAqN6IcszjTG8=";
+
+const LOGIN_TTL_MS = 15 * 60 * 1000;
+const MAX_PENDING_LOGINS = 20;
+export const HIRES_TIDDL_PATH = `${CONFIG_PATH}/.tiddl`;
+export const ATMOS_TIDDL_PATH = `${CONFIG_PATH}/.tiddl-atmos`;
+
+type PendingLogin = {
+  codeVerifier: string;
+  clientUniqueKey: string;
+  createdAt: number;
+};
+
+export type TidalProfile = "hires" | "atmos";
+
+export type TidalProfilePaths = {
+  hiresDirectory: string;
+  atmosphereDirectory: string;
+  authFile: string;
+  atmosphereAuthFile: string;
+};
+
+type TokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+};
+
+type SessionResponse = {
+  userId: string | number;
+  countryCode: string;
+};
+
+type RefreshPkceOptions = {
+  paths?: TidalProfilePaths;
+  request?: (body: URLSearchParams) => Promise<TokenResponse>;
+};
+
+const pendingLogins = new Map<string, PendingLogin>();
+let refreshPromise: Promise<TidalAuth> | null = null;
+
+export function createTidalProfilePaths(configPath: string): TidalProfilePaths {
+  const hiresDirectory = `${configPath}/.tiddl`;
+  const atmosphereDirectory = `${configPath}/.tiddl-atmos`;
+  return {
+    hiresDirectory,
+    atmosphereDirectory,
+    authFile: `${hiresDirectory}/auth.json`,
+    atmosphereAuthFile: `${atmosphereDirectory}/auth.json`,
+  };
+}
+
+const DEFAULT_PROFILE_PATHS = createTidalProfilePaths(CONFIG_PATH);
+
+function base64Url(value: Buffer): string {
+  return value.toString("base64url");
+}
+
+function cleanExpiredLogins() {
+  const expiresBefore = Date.now() - LOGIN_TTL_MS;
+  for (const [id, login] of pendingLogins) {
+    if (login.createdAt < expiresBefore) pendingLogins.delete(id);
+  }
+}
+
+function parseRedirectCode(redirectUrl: string, expectedState: string): string {
+  let url: URL;
+  try {
+    url = new URL(redirectUrl.trim());
+  } catch {
+    throw new Error("Paste the complete URL from the redirected TIDAL page.");
+  }
+
+  const expectedRedirect = new URL(TIDAL_PKCE_REDIRECT_URI);
+  if (
+    url.origin !== expectedRedirect.origin ||
+    url.pathname !== expectedRedirect.pathname
+  ) {
+    throw new Error(
+      "The URL is not the expected TIDAL authentication redirect.",
+    );
+  }
+
+  if (url.searchParams.get("state") !== expectedState) {
+    throw new Error(
+      "The TIDAL authentication state is missing or does not match this login request.",
+    );
+  }
+
+  const code = url.searchParams.get("code");
+  if (!code) {
+    throw new Error(
+      "The redirected TIDAL URL does not contain an authorization code.",
+    );
+  }
+  return code;
+}
+
+async function readError(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as {
+      error?: string;
+      error_description?: string;
+      userMessage?: string;
+    };
+    return (
+      data.error_description ||
+      data.userMessage ||
+      data.error ||
+      response.statusText
+    );
+  } catch {
+    return response.statusText;
+  }
+}
+
+async function requestToken(body: URLSearchParams): Promise<TokenResponse> {
+  const response = await fetch(TIDAL_AUTH_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `TIDAL authentication failed: ${await readError(response)}`,
+    );
+  }
+
+  const data = (await response.json()) as Partial<TokenResponse>;
+  if (!data.access_token || !data.expires_in) {
+    throw new Error("TIDAL returned an incomplete authentication response.");
+  }
+  return data as TokenResponse;
+}
+
+async function getSession(accessToken: string): Promise<SessionResponse> {
+  const response = await fetch(TIDAL_SESSION_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Unable to read the TIDAL session: ${await readError(response)}`,
+    );
+  }
+
+  const data = (await response.json()) as Partial<SessionResponse>;
+  if (data.userId === undefined || !data.countryCode) {
+    throw new Error("TIDAL returned an incomplete session response.");
+  }
+  return data as SessionResponse;
+}
+
+async function saveAuth(
+  auth: TidalAuth,
+  paths: TidalProfilePaths = DEFAULT_PROFILE_PATHS,
+): Promise<void> {
+  preserveLegacyAuthForAtmos(paths);
+  const temporaryFile = `${paths.authFile}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  await mkdir(paths.hiresDirectory, { recursive: true });
+  await writeFile(temporaryFile, JSON.stringify(auth), { mode: 0o600 });
+  await rename(temporaryFile, paths.authFile);
+}
+
+/**
+ * TIDAL exposes Hi-Res stereo and Dolby Atmos through different client
+ * profiles. Keep an existing device-login token before replacing it with the
+ * PKCE token so Tidarr can select the appropriate profile per download.
+ */
+export function preserveLegacyAuthForAtmos(
+  paths: TidalProfilePaths = DEFAULT_PROFILE_PATHS,
+): void {
+  if (!existsSync(paths.authFile) || existsSync(paths.atmosphereAuthFile)) {
+    return;
+  }
+
+  try {
+    const auth = JSON.parse(readFileSync(paths.authFile, "utf-8")) as TidalAuth;
+    if (!auth?.token || isPkceAuth(auth)) return;
+
+    prepareAtmosProfile(paths);
+    copyFileSync(paths.authFile, paths.atmosphereAuthFile);
+    chmodSync(paths.atmosphereAuthFile, 0o600);
+  } catch (error) {
+    console.warn("⚠️ [TIDAL] Could not preserve legacy Atmos token:", error);
+  }
+}
+
+export function prepareAtmosProfile(
+  paths: TidalProfilePaths = DEFAULT_PROFILE_PATHS,
+): void {
+  mkdirSync(paths.atmosphereDirectory, { recursive: true });
+
+  const sourceConfig = `${paths.hiresDirectory}/config.toml`;
+  const targetConfig = `${paths.atmosphereDirectory}/config.toml`;
+  if (existsSync(sourceConfig)) {
+    const temporaryConfig = `${targetConfig}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+    copyFileSync(sourceConfig, temporaryConfig);
+    renameSync(temporaryConfig, targetConfig);
+  }
+}
+
+export function getAtmosAuth(
+  paths: TidalProfilePaths = DEFAULT_PROFILE_PATHS,
+): TidalAuth | undefined {
+  try {
+    return JSON.parse(
+      readFileSync(paths.atmosphereAuthFile, "utf-8"),
+    ) as TidalAuth;
+  } catch {
+    return undefined;
+  }
+}
+
+export function hasAtmosAuth(
+  paths: TidalProfilePaths = DEFAULT_PROFILE_PATHS,
+): boolean {
+  return !!getAtmosAuth(paths)?.token;
+}
+
+export function startPkceLogin(): { loginId: string; loginUrl: string } {
+  cleanExpiredLogins();
+  while (pendingLogins.size >= MAX_PENDING_LOGINS) {
+    const oldestId = pendingLogins.keys().next().value as string | undefined;
+    if (!oldestId) break;
+    pendingLogins.delete(oldestId);
+  }
+
+  const loginId = randomBytes(18).toString("hex");
+  const codeVerifier = base64Url(randomBytes(32));
+  const codeChallenge = base64Url(
+    createHash("sha256").update(codeVerifier).digest(),
+  );
+  const clientUniqueKey = randomBytes(8).toString("hex");
+
+  pendingLogins.set(loginId, {
+    codeVerifier,
+    clientUniqueKey,
+    createdAt: Date.now(),
+  });
+
+  const loginUrl = new URL(TIDAL_LOGIN_URL);
+  loginUrl.search = new URLSearchParams({
+    response_type: "code",
+    redirect_uri: TIDAL_PKCE_REDIRECT_URI,
+    client_id: TIDAL_PKCE_CLIENT_ID,
+    lang: "EN",
+    appMode: "android",
+    client_unique_key: clientUniqueKey,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    restrict_signup: "true",
+    state: loginId,
+  }).toString();
+
+  return { loginId, loginUrl: loginUrl.toString() };
+}
+
+export async function completePkceLogin(
+  loginId: string,
+  redirectUrl: string,
+): Promise<TidalAuth> {
+  cleanExpiredLogins();
+  const pending = pendingLogins.get(loginId);
+  if (!pending) {
+    throw new Error(
+      "This login request expired. Start TIDAL authentication again.",
+    );
+  }
+
+  const code = parseRedirectCode(redirectUrl, loginId);
+  const token = await requestToken(
+    new URLSearchParams({
+      code,
+      client_id: TIDAL_PKCE_CLIENT_ID,
+      grant_type: "authorization_code",
+      redirect_uri: TIDAL_PKCE_REDIRECT_URI,
+      scope: "r_usr+w_usr+w_sub",
+      code_verifier: pending.codeVerifier,
+      client_unique_key: pending.clientUniqueKey,
+    }),
+  );
+  const session = await getSession(token.access_token);
+
+  const auth: TidalAuth = {
+    token: token.access_token,
+    refresh_token: token.refresh_token || "",
+    expires_at: Math.floor(Date.now() / 1000) + token.expires_in,
+    user_id: String(session.userId),
+    country_code: session.countryCode,
+    auth_type: "pkce",
+    is_pkce: true,
+  };
+
+  if (!auth.refresh_token) {
+    throw new Error("TIDAL did not return a refresh token.");
+  }
+
+  await saveAuth(auth);
+  pendingLogins.delete(loginId);
+  return auth;
+}
+
+export function isPkceAuth(auth?: Partial<TidalAuth>): boolean {
+  return auth?.auth_type === "pkce" || auth?.is_pkce === true;
+}
+
+export function selectTidalProfile(
+  atmosFilter?: string,
+  atmosphereAvailable = hasAtmosAuth(),
+): TidalProfile {
+  if (
+    atmosphereAvailable &&
+    (atmosFilter === "only" || atmosFilter === "allow")
+  ) {
+    return "atmos";
+  }
+  return "hires";
+}
+
+export function needsTokenRefresh(
+  auth?: Partial<TidalAuth>,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  refreshWindowSeconds = 15 * 60,
+): boolean {
+  return (
+    typeof auth?.expires_at === "number" &&
+    auth.expires_at <= nowSeconds + refreshWindowSeconds
+  );
+}
+
+export function getTiddlEnvironment(
+  auth?: Partial<TidalAuth>,
+  profile: TidalProfile = "hires",
+  paths: TidalProfilePaths = DEFAULT_PROFILE_PATHS,
+): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  delete environment.TIDDL_AUTH;
+
+  if (profile === "atmos") {
+    prepareAtmosProfile(paths);
+    environment.TIDDL_PATH = paths.atmosphereDirectory;
+    return environment;
+  }
+
+  environment.TIDDL_PATH = paths.hiresDirectory;
+  if (isPkceAuth(auth)) {
+    environment.TIDDL_AUTH = `${TIDAL_PKCE_CLIENT_ID};${TIDAL_PKCE_CLIENT_SECRET}`;
+  }
+  return environment;
+}
+
+export async function refreshPkceAuth(
+  auth: TidalAuth,
+  options: RefreshPkceOptions = {},
+): Promise<TidalAuth> {
+  if (refreshPromise) return refreshPromise;
+  if (!auth.refresh_token) throw new Error("TIDAL refresh token is missing.");
+
+  refreshPromise = (async () => {
+    const token = await (options.request || requestToken)(
+      new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: auth.refresh_token,
+        client_id: TIDAL_PKCE_CLIENT_ID,
+        client_secret: TIDAL_PKCE_CLIENT_SECRET,
+      }),
+    );
+
+    const refreshed: TidalAuth = {
+      ...auth,
+      token: token.access_token,
+      refresh_token: token.refresh_token || auth.refresh_token,
+      expires_at: Math.floor(Date.now() / 1000) + token.expires_in,
+      auth_type: "pkce",
+      is_pkce: true,
+    };
+    await saveAuth(refreshed, options.paths);
+    return refreshed;
+  })().finally(() => {
+    refreshPromise = null;
+  });
+
+  return refreshPromise;
+}

--- a/api/src/services/tiddl.ts
+++ b/api/src/services/tiddl.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "child_process";
 import { Express, Request, Response } from "express";
+import { chmodSync } from "fs";
 
 import {
   CONFIG_PATH,
@@ -10,6 +11,19 @@ import { get_tiddl_config } from "../helpers/get_tiddl_config";
 import { extractFirstLineClean } from "../processing/utils/ansi-parse";
 import { logs } from "../processing/utils/logs";
 import { ProcessingItemType, TiddlConfig } from "../types";
+
+import {
+  ATMOS_TIDDL_PATH,
+  getAtmosAuth,
+  getTiddlEnvironment,
+  hasAtmosAuth,
+  isPkceAuth,
+  needsTokenRefresh,
+  prepareAtmosProfile,
+  refreshPkceAuth,
+  selectTidalProfile,
+  TidalProfile,
+} from "./tidal-pkce";
 
 // Constants
 const TIDDL_BINARY = "tiddl";
@@ -82,9 +96,12 @@ export function tidalDL(id: string, app: Express, onFinish?: () => void) {
   logs(item.id, `🕖 [TIDDL] Executing: ${TIDDL_BINARY} ${args.join(" ")}`);
   logs(item.id, "\r\n");
 
+  const profile = selectTidalProfile(item.atmosFilter);
+  const auth = profile === "atmos" ? getAtmosAuth() : config.auth;
+
   const child = spawn(TIDDL_BINARY, args, {
     env: {
-      ...process.env,
+      ...getTiddlEnvironment(auth, profile),
       FORCE_COLOR: "1",
       TERM: "xterm-256color",
     },
@@ -219,13 +236,15 @@ export function tidalDL(id: string, app: Express, onFinish?: () => void) {
   return child;
 }
 
-export function tidalToken(req: Request, res: Response) {
-  console.log("🔑 [TIDDL] User requested new authentication ...");
+export function tidalAtmosToken(req: Request, res: Response) {
+  console.log("🔑 [TIDDL] User requested new Atmos authentication ...");
+
+  prepareAtmosProfile();
 
   // User explicitly requested login, so proceed with authentication
   // (No need to check existing token - user wants to re-authenticate)
   const tiddlProcess = spawn(TIDDL_BINARY, ["auth", "login"], {
-    env: { ...process.env },
+    env: getTiddlEnvironment(getAtmosAuth(), "atmos"),
   });
 
   tiddlProcess.stdout.on("data", (data) => {
@@ -240,9 +259,18 @@ export function tidalToken(req: Request, res: Response) {
 
   tiddlProcess.on("close", (code) => {
     if (code === 0) {
-      res.write(
-        `data: Authenticated! Token saved to ${CONFIG_PATH}/.tiddl/auth.json\n\n`,
-      );
+      const authPath = `${ATMOS_TIDDL_PATH}/auth.json`;
+      try {
+        chmodSync(authPath, 0o600);
+      } catch (error) {
+        res.write(
+          "data: AuthError: Atmos authentication file was not created.\n\n",
+        );
+        console.error("❌ [TIDDL] Atmos auth file was not created:", error);
+        res.end();
+        return;
+      }
+      res.write(`data: Authenticated! Token saved to ${authPath}\n\n`);
       console.log("✅ [TIDDL]: Authenticated !");
 
       // Reload tiddl config to include new auth tokens
@@ -263,8 +291,9 @@ export function tidalToken(req: Request, res: Response) {
 
 export function deleteTiddlConfig() {
   try {
+    const { config } = get_tiddl_config();
     const result = spawnSync(TIDDL_BINARY, ["auth", "logout", "--force"], {
-      env: { ...process.env },
+      env: getTiddlEnvironment(config.auth),
       encoding: "utf-8",
     });
     if (result.status === 0) {
@@ -277,20 +306,51 @@ export function deleteTiddlConfig() {
           (result.stderr ? `:\n${result.stderr.trim()}` : ""),
       );
     }
+
+    if (hasAtmosAuth()) {
+      const atmosphereResult = spawnSync(
+        TIDDL_BINARY,
+        ["auth", "logout", "--force"],
+        {
+          env: getTiddlEnvironment(getAtmosAuth(), "atmos"),
+          encoding: "utf-8",
+        },
+      );
+      if (atmosphereResult.status === 0) {
+        console.log(
+          `✅ [TIDDL] Atmos auth tokens deleted from ${ATMOS_TIDDL_PATH}/auth.json`,
+        );
+      } else {
+        console.error(
+          `❌ [TIDDL] Atmos auth logout exited with code ${atmosphereResult.status}` +
+            (atmosphereResult.stderr
+              ? `:\n${atmosphereResult.stderr.trim()}`
+              : ""),
+        );
+      }
+    }
   } catch (e) {
     console.error("❌ [TIDDL] Error deleting tiddl config:", e);
   }
 }
 
-export async function refreshTidalToken(): Promise<void> {
-  console.log("🕖 [TIDDL] Refreshing Tidal token...");
+export async function refreshTidalToken(
+  profile: TidalProfile = "hires",
+): Promise<void> {
+  console.log(`🕖 [TIDDL] Refreshing ${profile} Tidal token...`);
+
+  const { config } = get_tiddl_config();
+  const auth = profile === "atmos" ? getAtmosAuth() : config.auth;
+  if (profile === "hires" && isPkceAuth(auth)) {
+    await refreshPkceAuth(config.auth);
+    console.log("✅ [TIDAL] Hi-Res token refreshed.");
+    return;
+  }
 
   // Use async spawn and wait for completion
   return new Promise((resolve) => {
     const refreshProcess = spawn(TIDDL_BINARY, ["auth", "refresh"], {
-      env: {
-        ...process.env,
-      },
+      env: getTiddlEnvironment(auth, profile),
     });
 
     const stderrChunks: Buffer[] = [];
@@ -298,8 +358,12 @@ export async function refreshTidalToken(): Promise<void> {
 
     refreshProcess.on("close", async (code) => {
       if (code === 0) {
+        const authPath =
+          profile === "atmos"
+            ? `${ATMOS_TIDDL_PATH}/auth.json`
+            : `${CONFIG_PATH}/.tiddl/auth.json`;
         console.log(
-          `✅ [TIDDL] Tidal token refreshed and saved to ${CONFIG_PATH}/.tiddl/auth.json`,
+          `✅ [TIDDL] Tidal token refreshed and saved to ${authPath}`,
         );
         // Wait 500ms to ensure file is written to disk before resolving
         await new Promise((r) => setTimeout(r, 500));
@@ -317,4 +381,31 @@ export async function refreshTidalToken(): Promise<void> {
       resolve(); // Resolve anyway to not block the caller
     });
   });
+}
+
+/**
+ * Refresh before Tiddl starts so its built-in refresh command never changes
+ * the client identity of a PKCE token near expiry.
+ */
+export async function ensureTidalTokenFresh(
+  app: Express,
+  item?: ProcessingItemType,
+): Promise<void> {
+  const atmosphereAvailable = hasAtmosAuth();
+  if (item?.atmosFilter === "only" && !atmosphereAvailable) {
+    throw new Error(
+      "Atmos authentication is required. Add it in Settings → Tiddl configuration.",
+    );
+  }
+
+  const profile = selectTidalProfile(item?.atmosFilter, atmosphereAvailable);
+  const auth =
+    profile === "atmos" ? getAtmosAuth() : app.locals.tiddlConfig?.auth;
+  if (!needsTokenRefresh(auth)) return;
+
+  await refreshTidalToken(profile);
+  if (profile === "hires") {
+    const { config } = get_tiddl_config();
+    app.locals.tiddlConfig = config;
+  }
 }

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -97,14 +97,18 @@ export type TiddlConfig = {
       mix?: string;
     };
   };
-  auth: {
-    token: string;
-    refresh_token: string;
-    expires: number;
-    expires_at?: number; // Unix timestamp when token expires (used for refresh logic)
-    user_id: string;
-    country_code: string;
-  };
+  auth: TidalAuth;
+};
+
+export type TidalAuth = {
+  token: string;
+  refresh_token: string;
+  expires?: number;
+  expires_at?: number; // Unix timestamp when token expires (used for refresh logic)
+  user_id: string;
+  country_code: string;
+  auth_type?: "oauth" | "pkce";
+  is_pkce?: boolean;
 };
 
 // SYNC LIST
@@ -168,6 +172,8 @@ export interface SettingsResponse {
     ENABLE_HISTORY?: string;
   };
   noToken: boolean;
+  requiresPkceAuth: boolean;
+  noAtmosToken: boolean;
   tiddl_config?: TiddlConfig;
   configErrors?: string[];
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -112,6 +112,8 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "dist-test",
+    "src/**/*.test.ts"
   ]
 }

--- a/api/tsconfig.test.json
+++ b/api/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.test.ts"],
+  "exclude": ["node_modules", "dist", "dist-test"]
+}

--- a/app/src/components/Dialog/DialogAtmosToken.tsx
+++ b/app/src/components/Dialog/DialogAtmosToken.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import SpatialAudioIcon from "@mui/icons-material/SpatialAudio";
+import {
+  Alert,
+  CircularProgress,
+  Link,
+  Paper,
+  Typography,
+} from "@mui/material";
+import { EventSourceController } from "event-source-plus";
+import { useApiFetcher } from "src/provider/ApiFetcherProvider";
+
+import { DialogHandler } from ".";
+
+export function DialogAtmosToken({
+  open,
+  onClose,
+  onAuthenticated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onAuthenticated: () => void;
+}) {
+  const {
+    actions: { get_atmos_token_sse },
+  } = useApiFetcher();
+  const [loginUrl, setLoginUrl] = useState<string>();
+  const [message, setMessage] = useState<string>();
+  const [error, setError] = useState(false);
+  const started = useRef(false);
+  const controller = useRef<EventSourceController>();
+
+  useEffect(() => {
+    if (!open || started.current) return;
+    started.current = true;
+
+    const stream = get_atmos_token_sse((output) => {
+      const url = output.match(/https?:\/\/[^\s']+/)?.[0];
+      if (url) setLoginUrl(url);
+
+      if (output.includes("Authenticated!")) {
+        setMessage("Atmos authentication complete.");
+        onAuthenticated();
+      } else if (output.includes("AuthError") || output.includes("closing")) {
+        setError(true);
+        setMessage("Atmos authentication failed. Close this dialog and retry.");
+      }
+    });
+    controller.current = stream.controller;
+
+    return () => stream.controller.abort();
+  }, [get_atmos_token_sse, onAuthenticated, open]);
+
+  const close = () => {
+    controller.current?.abort();
+    started.current = false;
+    setLoginUrl(undefined);
+    setMessage(undefined);
+    setError(false);
+    onClose();
+  };
+
+  return (
+    <DialogHandler
+      title="Authenticate Dolby Atmos"
+      icon={<SpatialAudioIcon color="primary" />}
+      open={open}
+      onClose={close}
+    >
+      <Typography sx={{ mb: 2 }}>
+        Atmos uses a separate TIDAL device profile. Open the link below and
+        approve access with the same account used for Hi-Res authentication.
+      </Typography>
+      <Paper
+        elevation={0}
+        sx={{
+          padding: "1rem",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        {loginUrl ? (
+          <Link href={loginUrl} target="_blank" rel="noreferrer">
+            {loginUrl}
+          </Link>
+        ) : (
+          <>
+            Preparing Atmos login…
+            <CircularProgress size={16} sx={{ mx: 2 }} />
+          </>
+        )}
+      </Paper>
+      <Typography sx={{ fontStyle: "italic", fontSize: 14, py: 1 }}>
+        This dialog updates automatically after TIDAL confirms the login.
+      </Typography>
+      {message && (
+        <Alert severity={error ? "error" : "success"}>{message}</Alert>
+      )}
+    </DialogHandler>
+  );
+}

--- a/app/src/components/Dialog/DialogToken.tsx
+++ b/app/src/components/Dialog/DialogToken.tsx
@@ -1,72 +1,73 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import WarningIcon from "@mui/icons-material/Warning";
-import { CircularProgress, Link, Paper, Typography } from "@mui/material";
-import { EventSourceController } from "event-source-plus";
+import {
+  Button,
+  CircularProgress,
+  Link,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { useApiFetcher } from "src/provider/ApiFetcherProvider";
 import { useConfigProvider } from "src/provider/ConfigProvider";
 
 import { DialogHandler } from ".";
 
 export const DialogToken = () => {
-  const { tokenMissing } = useConfigProvider();
+  const { requiresPkceAuth, tokenMissing } = useConfigProvider();
+  const authenticationRequired = tokenMissing || requiresPkceAuth;
   const {
-    actions: { get_token_sse },
+    actions: { complete_pkce_login, start_pkce_login },
   } = useApiFetcher();
-  const [output, setOutput] = useState<string>();
-  const [error, setError] = useState<boolean>(false);
+  const [loginId, setLoginId] = useState<string>();
+  const [loginUrl, setLoginUrl] = useState<string>();
+  const [redirectUrl, setRedirectUrl] = useState("");
+  const [message, setMessage] = useState<string>();
+  const [loading, setLoading] = useState(false);
   const [forceClose, setForceClose] = useState<boolean>(false);
-  const [sseController, setSseController] = useState<AbortController>();
+  const started = useRef(false);
 
   useEffect(() => {
-    function runTokenSSE(controller: EventSourceController) {
-      setOutput("");
-      setSseController(controller);
-    }
+    if (!authenticationRequired || started.current) return;
+    started.current = true;
+    setLoading(true);
+    start_pkce_login()
+      .then((login) => {
+        setLoginId(login?.loginId);
+        setLoginUrl(login?.loginUrl);
+        if (!login) setMessage("Unable to start TIDAL authentication.");
+      })
+      .finally(() => setLoading(false));
+  }, [authenticationRequired, start_pkce_login]);
 
-    if (!tokenMissing || error) return;
-
-    const { controller } = get_token_sse(setOutput);
-    runTokenSSE(controller);
-  }, [error, get_token_sse, tokenMissing]);
-
-  useEffect(() => {
-    function closeSSE(isError?: boolean, message?: string) {
-      if (message) setOutput(message);
-      if (isError) setError(true);
+  const completeLogin = async () => {
+    if (!loginId || !redirectUrl.trim()) return;
+    setLoading(true);
+    setMessage(undefined);
+    const result = await complete_pkce_login(loginId, redirectUrl);
+    setLoading(false);
+    if (result?.success) {
+      setMessage("Authenticated!");
+      window.location.reload();
       return;
     }
-
-    if (!tokenMissing) return;
-
-    if (output?.includes("Authenticated!")) {
-      closeSSE(false, "Authenticated !");
-      window.location.reload();
-    }
-    if (output?.includes("AuthError")) {
-      closeSSE(true);
-    }
-  }, [output, sseController, tokenMissing]);
-
-  useEffect(() => {
-    if ((tokenMissing || !!sseController) && !error) return;
-    setTimeout(() => {
-      console.log("Closing token SSE.");
-      setSseController(undefined);
-      sseController?.abort();
-    });
-  }, [sseController, tokenMissing, error]);
+    setMessage(result?.message || "Unable to complete TIDAL authentication.");
+  };
 
   return (
     <DialogHandler
-      title={"Tidal token not found !"}
+      title={
+        requiresPkceAuth
+          ? "Upgrade TIDAL authentication"
+          : "Tidal token not found !"
+      }
       icon={<WarningIcon color="error" />}
       onClose={() => {
         setForceClose(true);
-        sseController?.abort();
       }}
-      open={!!tokenMissing && !forceClose}
+      open={authenticationRequired && !forceClose}
     >
-      <p>Click on the link below to authenticate:</p>
+      <p>Open this link and sign in to TIDAL:</p>
       <Paper
         elevation={0}
         sx={{
@@ -77,10 +78,10 @@ export const DialogToken = () => {
           lineHeight: "1",
         }}
       >
-        <Link href={output} target="_blank">
-          {output}
+        <Link href={loginUrl} target="_blank" rel="noreferrer">
+          {loginUrl || "Preparing secure login…"}
         </Link>
-        {sseController && <CircularProgress size={16} sx={{ mx: 2 }} />}
+        {loading && <CircularProgress size={16} sx={{ mx: 2 }} />}
       </Paper>
       <Typography
         sx={{
@@ -89,17 +90,28 @@ export const DialogToken = () => {
           py: 1,
         }}
       >
-        This dialog will close after authentication.
+        After login, TIDAL redirects to an “Oops” page. Copy its complete URL
+        from the browser address bar and paste it below. This Hi-Res login is
+        required for stereo fallback and MAX-quality FLAC.
       </Typography>
-      <p>
-        ... or create Tidal token using CLI :{" "}
-        <Link
-          href="https://github.com/cstaelen/tidarr?tab=readme-ov-file#tidal-authentication"
-          target="_blank"
-        >
-          Github
-        </Link>
-      </p>
+      <TextField
+        fullWidth
+        label="Redirected TIDAL URL"
+        placeholder="https://tidal.com/android/login/auth?code=…"
+        value={redirectUrl}
+        onChange={(event) => setRedirectUrl(event.target.value)}
+        error={!!message && message !== "Authenticated!"}
+        helperText={message}
+        sx={{ mt: 1 }}
+      />
+      <Button
+        variant="contained"
+        disabled={loading || !loginId || !redirectUrl.trim()}
+        onClick={completeLogin}
+        sx={{ mt: 2 }}
+      >
+        Complete authentication
+      </Button>
     </DialogHandler>
   );
 };

--- a/app/src/components/Parameters/TidalPanel.tsx
+++ b/app/src/components/Parameters/TidalPanel.tsx
@@ -12,14 +12,16 @@ import { useApiFetcher } from "src/provider/ApiFetcherProvider";
 import { useConfigProvider } from "src/provider/ConfigProvider";
 import { useHistoryProvider } from "src/provider/HistoryProvider";
 
+import { DialogAtmosToken } from "../Dialog/DialogAtmosToken";
 import { ModuleTitle } from "../TidalModule/Title";
 
 import TiddlConfigEdit from "./tidal/TiddlConfigEdit";
 import TiddlConfigList from "./tidal/TiddlConfigList";
 
 export default function TidalPanel() {
-  const { tokenMissing } = useConfigProvider();
+  const { noAtmosToken, requiresPkceAuth, tokenMissing } = useConfigProvider();
   const [showEditor, setShowEditor] = useState<boolean>();
+  const [showAtmosLogin, setShowAtmosLogin] = useState(false);
   const [historyFlushed, setHistoryFlushed] = useState<boolean>();
   const navigate = useNavigate();
 
@@ -55,6 +57,27 @@ export default function TidalPanel() {
             No Tidal token found !
           </Alert>
         </Box>
+      )}
+      {requiresPkceAuth && (
+        <Alert color="warning" variant="outlined" sx={{ mb: 3 }}>
+          This legacy TIDAL token cannot reliably request stereo or MAX streams.
+          Re-authenticate from the home page using the Hi-Res login.
+        </Alert>
+      )}
+      {!tokenMissing && !requiresPkceAuth && noAtmosToken && (
+        <Alert
+          color="warning"
+          variant="outlined"
+          sx={{ mb: 3 }}
+          action={
+            <Button color="inherit" onClick={() => setShowAtmosLogin(true)}>
+              Authenticate Atmos
+            </Button>
+          }
+        >
+          MAX stereo is ready. Dolby Atmos needs one additional TIDAL device
+          login before “Atmos only” or “Atmos allowed” can select Atmos streams.
+        </Alert>
       )}
       <Box
         component="span"
@@ -106,6 +129,11 @@ export default function TidalPanel() {
         )}
       </Box>
       {showEditor ? <TiddlConfigEdit /> : <TiddlConfigList />}
+      <DialogAtmosToken
+        open={showAtmosLogin}
+        onClose={() => setShowAtmosLogin(false)}
+        onAuthenticated={checkAPI}
+      />
     </>
   );
 }

--- a/app/src/provider/ApiFetcherProvider.tsx
+++ b/app/src/provider/ApiFetcherProvider.tsx
@@ -43,9 +43,14 @@ type ApiFetcherContextType = {
     retry_failed: () => Promise<unknown>;
     auth: (body: string) => Promise<AuthType | undefined>;
     is_auth_active: () => Promise<CheckAuthType | undefined>;
-    get_token_sse: (
-      setOutput: React.Dispatch<React.SetStateAction<string | undefined>>,
-    ) => {
+    start_pkce_login: () => Promise<
+      { loginId: string; loginUrl: string } | undefined
+    >;
+    complete_pkce_login: (
+      loginId: string,
+      redirectUrl: string,
+    ) => Promise<{ success: boolean; message: string } | undefined>;
+    get_atmos_token_sse: (onOutput: (output: string) => void) => {
       eventSource: EventSourcePlus;
       controller: EventSourceController;
     };
@@ -268,29 +273,30 @@ export function APIFetcherProvider({ children }: { children: ReactNode }) {
 
   // Tidal token
 
-  function get_token_sse(
-    setOutput: React.Dispatch<React.SetStateAction<string | undefined>>,
-  ): {
+  async function start_pkce_login() {
+    return await queryExpressJS<{ loginId: string; loginUrl: string }>(
+      `${apiUrl}/token/pkce/start`,
+    );
+  }
+
+  async function complete_pkce_login(loginId: string, redirectUrl: string) {
+    return await queryExpressJS<{ success: boolean; message: string }>(
+      `${apiUrl}/token/pkce/complete`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ loginId, redirectUrl }),
+      },
+    );
+  }
+
+  function get_atmos_token_sse(onOutput: (output: string) => void): {
     eventSource: EventSourcePlus;
     controller: EventSourceController;
   } {
-    const { eventSource, controller } = streamExpressJS(
-      `${apiUrl}/run-token`,
-      (message) => {
-        if (message.data?.length === 0) return;
-
-        const url = message.data
-          .match(/https?:\/\/[^\s]+/)?.[0]
-          .replace("'", "");
-        if (url) {
-          setOutput(url);
-        } else {
-          setOutput(message.data);
-        }
-      },
-    );
-
-    return { eventSource, controller };
+    return streamExpressJS(`${apiUrl}/token/atmos`, (message) => {
+      if (message.data?.length > 0) onOutput(message.data);
+    });
   }
 
   async function delete_token() {
@@ -551,7 +557,9 @@ export function APIFetcherProvider({ children }: { children: ReactNode }) {
       retry_failed,
       auth,
       is_auth_active,
-      get_token_sse,
+      start_pkce_login,
+      complete_pkce_login,
+      get_atmos_token_sse,
       delete_token,
       get_sync_list,
       add_sync_item,

--- a/app/src/provider/ConfigProvider.tsx
+++ b/app/src/provider/ConfigProvider.tsx
@@ -46,6 +46,8 @@ type ConfigContextType = {
   changeLogData: string[];
   unseenReleases: ReleaseGithubType[];
   tokenMissing: boolean;
+  requiresPkceAuth: boolean;
+  noAtmosToken: boolean;
   quality: undefined | QualityType;
   atmosFilter: undefined | AtmosFilterType;
   display: DisplayType;
@@ -70,6 +72,8 @@ const ConfigContext = React.createContext<ConfigContextType>(
 export function ConfigProvider({ children }: { children: ReactNode }) {
   const [isUpdateAvailable, setIsUpdateAvailable] = useState(false);
   const [tokenMissing, setTokenMissing] = useState(false);
+  const [requiresPkceAuth, setRequiresPkceAuth] = useState(false);
+  const [noAtmosToken, setNoAtmosToken] = useState(false);
   const [releaseData, setReleaseData] = useState<ReleaseGithubType>();
   const [changeLogData, setChangeLogData] = useState<string[]>([]);
   const [unseenReleases, setUnseenReleases] = useState<ReleaseGithubType[]>([]);
@@ -104,6 +108,8 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     const data = output as ConfigType;
 
     setTokenMissing(data?.noToken);
+    setRequiresPkceAuth(data?.requiresPkceAuth);
+    setNoAtmosToken(data?.noAtmosToken);
     setConfig(data?.parameters);
     setTiddlConfig(data?.tiddl_config);
     setConfigErrors(data?.configErrors);
@@ -191,6 +197,8 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     changeLogData,
     unseenReleases,
     tokenMissing,
+    requiresPkceAuth,
+    noAtmosToken,
     config,
     quality,
     atmosFilter,

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -240,6 +240,8 @@ export type ModuleTypeKeys =
 
 export type ConfigType = {
   noToken: boolean;
+  requiresPkceAuth: boolean;
+  noAtmosToken: boolean;
   output: string;
   parameters: ConfigParametersType;
   tiddl_config: ConfigTiddleType;
@@ -303,6 +305,8 @@ export type ConfigTiddleType = {
     expires_at: number;
     user_id: string;
     country_code: string;
+    auth_type?: "oauth" | "pkce";
+    is_pkce?: boolean;
   };
 };
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -599,17 +599,91 @@ curl http://localhost:8484/api/settings \
 
 ---
 
-### Run Tidal authentication flow
+### Legacy Tidal authentication endpoint
 
 ```bash
 GET /api/run-token
 ```
 
-SSE endpoint that initiates the Tidal device authentication flow. Opens a stream that sends authentication events (login URL, status updates) until authentication completes or fails.
+This endpoint is deprecated and returns `410 Gone`. It cannot safely preserve
+the old behavior because the primary and Atmos profiles now use different
+authentication flows.
 
-**Response:** `text/event-stream`
+Use `/api/token/pkce/start` followed by `/api/token/pkce/complete` for the
+primary Hi-Res profile, or `/api/token/atmos` for the secondary Atmos profile.
 
-**Note:** This endpoint is used by the web UI during initial Tidal setup. Events are streamed until authentication completes.
+**Response:**
+
+```json
+{
+  "message": "This authentication endpoint was replaced by the Hi-Res PKCE and Atmos profile endpoints.",
+  "pkceStart": "/api/token/pkce/start",
+  "pkceComplete": "/api/token/pkce/complete",
+  "atmosphere": "/api/token/atmos"
+}
+```
+
+---
+
+### Start Hi-Res TIDAL authentication
+
+Use this PKCE flow so TIDAL can return stereo and MAX streams.
+
+```http
+GET /api/token/pkce/start
+```
+
+Returns a short-lived login identifier and a TIDAL URL:
+
+```json
+{
+  "loginId": "...",
+  "loginUrl": "https://login.tidal.com/authorize?..."
+}
+```
+
+Open `loginUrl`, sign in, and copy the complete URL of the redirected TIDAL
+page. The apparent “Oops” page is expected.
+
+### Complete Hi-Res TIDAL authentication
+
+```http
+POST /api/token/pkce/complete
+Content-Type: application/json
+
+{
+  "loginId": "...",
+  "redirectUrl": "https://tidal.com/android/login/auth?code=...&state=..."
+}
+```
+
+The completion request validates the returned OAuth state against the
+short-lived login request before exchanging the authorization code.
+
+On success, Tidarr stores a refreshable PKCE token and returns:
+
+```json
+{
+  "success": true,
+  "message": "Authenticated!"
+}
+```
+
+If a legacy device token exists when PKCE authentication is completed, Tidarr
+preserves it as the Dolby Atmos profile. The download service uses the PKCE
+profile for `--dolby-atmos none` and the device profile for
+`--dolby-atmos only` or `allow`.
+
+### Authenticate Dolby Atmos profile
+
+```http
+GET /api/token/atmos
+Accept: text/event-stream
+```
+
+Starts Tiddl's device authorization in a separate profile directory and emits
+the TIDAL verification URL and completion status as server-sent events. This is
+needed on fresh installations that do not have a legacy token to preserve.
 
 ---
 

--- a/e2e/tests/config.spec.ts
+++ b/e2e/tests/config.spec.ts
@@ -14,7 +14,18 @@ test("Tidarr config : Should display token modal if no tidal token exists", asyn
 }) => {
   await mockConfigAPI(page, {
     noToken: true,
+    requiresPkceAuth: false,
+    noAtmosToken: true,
     tiddl_config: { auth: { country_code: "FR" } },
+  });
+
+  await page.route("**/token/pkce/start", async (route) => {
+    await route.fulfill({
+      json: {
+        loginId: "test-login",
+        loginUrl: "https://login.tidal.com/authorize?test=1",
+      },
+    });
   });
 
   await page.goto("/");
@@ -24,7 +35,71 @@ test("Tidarr config : Should display token modal if no tidal token exists", asyn
   ).toBeVisible();
 
   await expect(
-    page.getByRole("link", { name: "https://link.tidal.com/" }),
+    page.getByRole("link", {
+      name: "https://login.tidal.com/authorize?test=1",
+    }),
+  ).toBeVisible();
+
+  await expect(page.getByLabel("Redirected TIDAL URL")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Complete authentication" }),
+  ).toBeDisabled();
+});
+
+test("Tidarr config : Should prompt legacy tokens to upgrade", async ({
+  page,
+}) => {
+  await mockConfigAPI(page, {
+    noToken: false,
+    requiresPkceAuth: true,
+    noAtmosToken: true,
+  });
+  await page.route("**/token/pkce/start", async (route) => {
+    await route.fulfill({
+      json: {
+        loginId: "upgrade-login",
+        loginUrl: "https://login.tidal.com/authorize?upgrade=1",
+      },
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "Upgrade TIDAL authentication" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/required for stereo fallback and MAX-quality FLAC/),
+  ).toBeVisible();
+});
+
+test("Tidarr config : Should offer a separate Atmos login", async ({
+  page,
+}) => {
+  await mockConfigAPI(page, {
+    noToken: false,
+    requiresPkceAuth: false,
+    noAtmosToken: true,
+  });
+  await page.route("**/token/atmos", async (route) => {
+    await route.fulfill({
+      contentType: "text/event-stream",
+      body: "data: https://link.tidal.com/atmos-test\n\n",
+    });
+  });
+
+  await page.goto("/parameters");
+  await page.getByRole("tab", { name: "Tidal" }).click();
+
+  await expect(
+    page.getByText(/Dolby Atmos needs one additional/),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Authenticate Atmos" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Authenticate Dolby Atmos" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "https://link.tidal.com/atmos-test" }),
   ).toBeVisible();
 });
 

--- a/e2e/tests/utils/mock.ts
+++ b/e2e/tests/utils/mock.ts
@@ -182,6 +182,8 @@ export async function mockConfigAPI(
       const json = {
         ...realConfig,
         noToken: false,
+        requiresPkceAuth: false,
+        noAtmosToken: false,
         ...customSettings,
         parameters: {
           ...realConfig?.parameters,
@@ -196,6 +198,8 @@ export async function mockConfigAPI(
             expires_at: 1234567890,
             user_id: "192283714",
             country_code: "FR",
+            auth_type: "pkce",
+            is_pkce: true,
           },
         },
       };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "app-build": "yarn --cwd ./app build",
     "api-build": "yarn --cwd ./api build",
+    "api-test": "yarn --cwd ./api test",
     "dev": "concurrently -n api,front \"yarn --cwd ./api start\" \"yarn --cwd app start\"",
     "prod": "node ./api/dist/index.js",
     "eslint": "eslint .",


### PR DESCRIPTION
## Summary

This adds separate TIDAL authentication profiles for Hi-Res/MAX stereo and
Dolby Atmos downloads.

- Add a Hi-Res-capable PKCE authentication flow.
- Keep the legacy Tiddl device token as a separate Atmos profile.
- Select the appropriate profile from the Atmos filter.
- Refresh both profiles independently with their original client identity.
- Preserve an existing device token automatically when upgrading.
- Add an Atmos authentication action for fresh installations.
- Document the new authentication flow and add API/UI coverage.

## Why

TIDAL stream availability depends on the client profile used during
authentication, not only on the requested quality or `--dolby-atmos` option.

The legacy Tiddl device profile can receive Dolby Atmos streams, but stereo
downloads may be limited to 16-bit LOSSLESS even when a MAX/Hi-Res version is
available.

The Hi-Res PKCE profile can receive MAX/Hi-Res stereo and can select the stereo
version of releases that otherwise resolve to Atmos, but it does not receive
Dolby Atmos streams. One authentication profile therefore cannot currently
provide both behaviors.

## Profile selection

| Atmos filter | Authentication profile | Result |
| --- | --- | --- |
| No Atmos | Hi-Res PKCE | Stereo, up to available MAX/Hi-Res quality |
| Atmos only | Device/Atmos | Dolby Atmos; reports a clear error if the profile is missing |
| Atmos allowed | Device/Atmos when configured | Allows Atmos, with legacy stereo fallback |
| Atmos allowed without an Atmos profile | Hi-Res PKCE | Stereo fallback without blocking the download |

## Migration and hardening

When an existing legacy token is present, completing PKCE authentication copies
it to a separate `.tiddl-atmos` profile before replacing the primary token.
Fresh installations can add the Atmos profile from **Settings → Tiddl
configuration → Authenticate Atmos**.

- Bind every PKCE request to a random OAuth `state` and validate the returned
  state and redirect target before exchanging the code.
- Write token/config changes atomically and store authentication files with mode
  `0600`.
- Keep live runtime credentials and configuration out of Git.
- Return `410 Gone` from the deprecated `/api/run-token` endpoint with links to
  the explicit PKCE and Atmos replacements.

## Validation

A TIDAL track available in both MAX quality and Dolby Atmos was tested
end-to-end with both authentication profiles:

- **No Atmos + MAX** selected the stereo manifest and downloaded
  `HI_RES_LOSSLESS` as a 24-bit / 96 kHz FLAC.
- **Atmos only** selected the `DOLBY_ATMOS` manifest and completed the download
  successfully.

This verifies that profile selection affects the stream returned by TIDAL and
preserves both capabilities, rather than only changing Tidarr's requested
quality or Atmos filter.

## Limitations

Tiddl uses one authentication profile for an entire download process.
Consequently, `Atmos allowed` uses the Atmos-capable profile and non-Atmos
tracks in that process may be limited to legacy LOSSLESS instead of MAX.

The client identity follows the public PKCE implementation used by
[`python-tidal`](https://github.com/tamland/python-tidal/blob/master/tidalapi/session.py).
This depends on TIDAL's current playback authentication behavior and may need
maintenance if that behavior changes.

Related: #777, #831, #862
